### PR TITLE
Add license, code of conduct and security information to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,21 @@
 
 pytest-memray is a pytest plugin for easy integration of `memray`.
 
-## Usage
+# Installation
+
+pytest-memray requires Python 3.7+ and can be easily installed using most common Python
+packaging tools. We recommend installing the latest stable release from
+[PyPI](https://pypi.org/project/pytest-memray/) with pip:
+
+```shell
+    pip install pytest-memray
+```
+
+# Documentation
+
+You can find the latest documentation available [here](https://bloomberg.github.io/pytest-memray/).
+
+# Usage
 
 To use the plugin in a pytest run, simply add `--memray` to the command line invocation:
 
@@ -77,3 +91,52 @@ Example of usage:
 def test_foobar():
     # do some stuff that allocates memory
 ```
+
+# License
+
+pytest-memray is Apache-2.0 licensed, as found in the [LICENSE](LICENSE) file.
+
+# Code of Conduct
+
+- [Code of Conduct](https://github.com/bloomberg/.github/blob/main/CODE_OF_CONDUCT.md)
+
+This project has adopted a Code of Conduct. If you have any concerns about the Code, or behavior which you have experienced in the project, please contact us at opensource@bloomberg.net.
+
+# Security Policy
+
+- [Security Policy](https://github.com/bloomberg/pytest-memray/security/policy)
+
+If you believe you have identified a security vulnerability in this project, please send email to the project team at opensource@bloomberg.net, detailing the suspected issue and any methods you've found to reproduce it.
+
+Please do NOT open an issue in the GitHub repository, as we'd prefer to keep vulnerability reports private until we've had an opportunity to review and address them.
+
+# Contributing
+
+We welcome your contributions to help us improve and extend this project!
+
+Below you will find some basic steps required to be able to contribute to the project. If you have any questions about this process or any other aspect of contributing to a Bloomberg open source project, feel free to send an email to opensource@bloomberg.net and we'll get your questions answered as quickly as we can.
+
+## Contribution Licensing
+
+Since this project is distributed under the terms of an [open source license](LICENSE), contributions that you make
+are licensed under the same terms. In order for us to be able to accept your contributions,
+we will need explicit confirmation from you that you are able and willing to provide them under
+these terms, and the mechanism we use to do this is called a Developer's Certificate of Origin
+[(DCO)](https://github.com/bloomberg/.github/blob/main/DCO.md). This is very similar to the process used by the Linux(R) kernel, Samba, and many
+other major open source projects.
+
+To participate under these terms, all that you must do is include a line like the following as the
+last line of the commit message for each commit in your contribution:
+
+    Signed-Off-By: Random J. Developer <random@developer.example.org>
+
+The simplest way to accomplish this is to add `-s` or `--signoff` to your `git commit` command.
+
+You must use your real name (sorry, no pseudonyms, and no anonymous contributions).
+
+## Steps
+
+- Create an Issue, selecting 'Feature Request', and explain the proposed change.
+- Follow the guidelines in the issue template presented to you.
+- Submit the Issue.
+- Submit a Pull Request and link it to the Issue by including "#<issue number>" in the Pull Request summary.


### PR DESCRIPTION
To improve the information available in the README file and to be
compliant with the OS requirements of the organization, add sections to
the README that include some description of the CoC, security and
license associated with the project
