### PR TITLE
Ensure the "longrepr" attribute is set on failing tests

### DIFF
--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -139,6 +139,7 @@ class Manager:
             )
             if result:
                 report.outcome = "failed"
+                report.longrepr = f"Memray detected problems with test {item.nodeid}"
                 report.sections.append(result)
                 outcome.force_result(report)
         return None


### PR DESCRIPTION
Some pytest functionality relies of the fact that the "longrepr"
attribute is not None for failing tests. According to pytest type
annotations this can be a string explaining why the test failed or some
complicated traceback object. As we cannot easily make a traceback
object, we can simply put a string explaining why the test failed.
