### PR TITLE
Release wheels besides sdist too

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -1,4 +1,4 @@
-name: Linux Wheels
+name: Build Distributions
 
 on:
   push:
@@ -14,23 +14,22 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-
 jobs:
-  build_sdist:
-    name: Build source distribution
+  build_dist:
+    name: Build source and wheel distributions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build sdist
-        run: pipx run build --sdist
+      - name: Build distributions
+        run: pipx run build[virtualenv] --sdist --wheel
 
       - uses: actions/upload-artifact@v2
         with:
-          path: dist/*.tar.gz
+          path: dist/*
 
   upload_pypi:
-    needs: [build_sdist]
+    needs: [build_dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:


### PR DESCRIPTION
Resolves #9.

As I don't have write access on the REPO the GHA is not run here, but you can see it run on my fork here. https://github.com/gaborbernat/pytest-memray/runs/6377932791?check_suite_focus=true:

```
Successfully built pytest-memray-1.0.0.tar.gz and pytest_memray-1.0.0-py3-none-any.whl
```