### PR TITLE
Allow to persist binary dumps past test suite run

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -20,6 +20,9 @@ The complete list of command line options is:
   ``--hide-memray-summary``
     Hide the memray summary at the end of the execution.
 
+  ``--memray-bin-path``
+    Path where to write the memray binary dumps (by default a temporary folder).
+
 .. tab:: Config file options
 
   ``memray(bool)``

--- a/docs/news/10.feature.rst
+++ b/docs/news/10.feature.rst
@@ -1,0 +1,2 @@
+Allow passing ``--memray-bin-path`` argument to the CLI to allow
+persisting the binary dumps - by :user:`gaborbernat`.

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -4,6 +4,7 @@ import collections
 import functools
 import inspect
 import math
+import os
 import uuid
 from dataclasses import dataclass
 from itertools import islice
@@ -105,6 +106,7 @@ class Manager:
                 name = f"{uuid.uuid4().hex}.bin"
             else:
                 of_id = pyfuncitem.nodeid.replace("::", "-")
+                of_id = of_id.replace(os.sep, "-")
                 name = f"{self._run_id}-{of_id}.bin"
             result_file = Path(self.result_path.name) / name
             with Tracker(result_file):

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -104,7 +104,8 @@ class Manager:
             if self._is_result_tmp:
                 name = f"{uuid.uuid4().hex}.bin"
             else:
-                name = f"{self._run_id}-{func.__module__}-{func.__qualname__}.bin"
+                of_id = pyfuncitem.nodeid.replace("::", "-")
+                name = f"{self._run_id}-{of_id}.bin"
             result_file = Path(self.result_path.name) / name
             with Tracker(result_file):
                 result: object | None = func(*args, **kwargs)

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -4,11 +4,11 @@ import collections
 import functools
 import inspect
 import math
-import pathlib
-import tempfile
 import uuid
 from dataclasses import dataclass
 from itertools import islice
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 from typing import Generator
 from typing import Iterable
@@ -32,6 +32,7 @@ from pytest import TestReport
 from pytest import hookimpl
 
 from .marks import limit_memory
+from .utils import WriteEnabledDirectoryAction
 from .utils import sizeof_fmt
 
 MARKERS = {"limit_memory": limit_memory}
@@ -75,30 +76,38 @@ ResultElement = List[Tuple[object, int]]
 @dataclass
 class Result:
     metadata: Metadata
-    result_file: pathlib.Path
+    result_file: Path
 
 
 class Manager:
     def __init__(self, config: Config) -> None:
         self.results: dict[str, Result] = {}
         self.config = config
-        self.result_path = tempfile.TemporaryDirectory()
+        path: Path | None = config.getvalue("memray_bin_path")
+        self.result_path: TemporaryDirectory[str] | Path = path or TemporaryDirectory()
+        self._is_result_tmp: bool = path is None
+        self._run_id = uuid.uuid4().hex
 
     @hookimpl(hookwrapper=True)  # type: ignore[misc] # Untyped decorator
     def pytest_unconfigure(self, config: Config) -> Generator[None, None, None]:
         yield
-        self.result_path.cleanup()
+        if self._is_result_tmp:
+            assert isinstance(self.result_path, TemporaryDirectory)
+            self.result_path.cleanup()
 
     @hookimpl(hookwrapper=True)  # type: ignore[misc] # Untyped decorator
     def pytest_pyfunc_call(self, pyfuncitem: Function) -> object | None:
-        testfunction = pyfuncitem.obj
+        func = pyfuncitem.obj
 
-        @functools.wraps(testfunction)
+        @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> object | None:
-            name = f"{uuid.uuid4().hex}.bin"
-            result_file = pathlib.Path(self.result_path.name) / name
+            if self._is_result_tmp:
+                name = f"{uuid.uuid4().hex}.bin"
+            else:
+                name = f"{self._run_id}-{func.__module__}-{func.__qualname__}.bin"
+            result_file = Path(self.result_path.name) / name
             with Tracker(result_file):
-                result: object | None = testfunction(*args, **kwargs)
+                result: object | None = func(*args, **kwargs)
             try:
                 metadata = FileReader(result_file).metadata
             except OSError:
@@ -219,6 +228,12 @@ def pytest_addoption(parser: Parser) -> None:
         action="store_true",
         default=False,
         help="Activate memray tracking",
+    )
+    group.addoption(
+        "--memray-bin-path",
+        action=WriteEnabledDirectoryAction,
+        default=None,
+        help="Path where to write the memray binary dumps (by default a temporary folder)",
     )
     group.addoption(
         "--hide-memray-summary",

--- a/tests/test_pytest_pensieve.py
+++ b/tests/test_pytest_pensieve.py
@@ -318,17 +318,16 @@ def test_plugin_calls_tests_only_once(pytester: Pytester) -> None:
 
 
 def test_bin_path(pytester: Pytester) -> None:
-    pytester.makepyfile(
-        """
-        import pytest
+    py = """
+    import pytest
 
-        def test_a():
-            assert [1]
-        @pytest.mark.parametrize('i', [1, 2])
-        def test_b(i):
-            assert [2] * i
-        """
-    )
+    def test_a():
+        assert [1]
+    @pytest.mark.parametrize('i', [1, 2])
+    def test_b(i):
+        assert [2] * i
+    """
+    pytester.makepyfile(**{"magic/test_a": py})
     dump = pytester.path / "d"
     with patch("uuid.uuid4", return_value=SimpleNamespace(hex="H")) as mock:
         result = pytester.runpytest("--memray", "--memray-bin-path", str(dump))
@@ -338,7 +337,7 @@ def test_bin_path(pytester: Pytester) -> None:
 
     assert dump.exists()
     assert {i.name for i in dump.iterdir()} == {
-        "H-test_bin_path.py-test_a.bin",
-        "H-test_bin_path.py-test_b[1].bin",
-        "H-test_bin_path.py-test_b[2].bin",
+        "H-magic-test_a.py-test_b[2].bin",
+        "H-magic-test_a.py-test_a.bin",
+        "H-magic-test_a.py-test_b[1].bin",
     }

--- a/tests/test_pytest_pensieve.py
+++ b/tests/test_pytest_pensieve.py
@@ -320,10 +320,13 @@ def test_plugin_calls_tests_only_once(pytester: Pytester) -> None:
 def test_bin_path(pytester: Pytester) -> None:
     pytester.makepyfile(
         """
+        import pytest
+
         def test_a():
             assert [1]
-        def test_b():
-            assert [2]
+        @pytest.mark.parametrize('i', [1, 2])
+        def test_b(i):
+            assert [2] * i
         """
     )
     dump = pytester.path / "d"
@@ -334,7 +337,8 @@ def test_bin_path(pytester: Pytester) -> None:
     mock.assert_called_once()
 
     assert dump.exists()
-    assert set(i.name for i in dump.iterdir()) == {
-        "H-test_bin_path-test_b.bin",
-        "H-test_bin_path-test_a.bin",
+    assert {i.name for i in dump.iterdir()} == {
+        "H-test_bin_path.py-test_a.bin",
+        "H-test_bin_path.py-test_b[1].bin",
+        "H-test_bin_path.py-test_b[2].bin",
     }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,19 @@
 from __future__ import annotations
 
+import re
+from argparse import ArgumentParser
+from argparse import Namespace
+from pathlib import Path
+from stat import S_IWGRP
+from stat import S_IWOTH
+from stat import S_IWUSR
+from typing import Callable
+from typing import NoReturn
+from unittest.mock import create_autospec
+
 import pytest
 
+from pytest_memray.utils import WriteEnabledDirectoryAction
 from pytest_memray.utils import parse_memory_string
 
 
@@ -52,3 +64,62 @@ def test_parse_memory_string(the_str: str, expected: float) -> None:
 def test_parse_incorrect_memory_string(the_str: str) -> None:
     with pytest.raises(ValueError):
         parse_memory_string(the_str)
+
+
+WDirCheck = Callable[[Path], Namespace]
+
+
+@pytest.fixture()
+def w_dir_check() -> WDirCheck:
+    def _func(path: Path) -> Namespace:
+        action = WriteEnabledDirectoryAction(option_strings=["-m"], dest="d")
+        parser = create_autospec(ArgumentParser)
+
+        def error(message: str) -> NoReturn:
+            raise ValueError(message)
+
+        parser.error.side_effect = error
+        namespace = Namespace()
+        action(parser, namespace, str(path))
+        return namespace
+
+    return _func
+
+
+def test_write_enabled_dir_ok(w_dir_check: WDirCheck, tmp_path: Path) -> None:
+    namespace = w_dir_check(tmp_path)
+    assert namespace.d == tmp_path
+
+
+def test_write_enabled_dir_is_file(w_dir_check: WDirCheck, tmp_path: Path) -> None:
+    path = tmp_path / "a"
+    path.write_text("")
+    exp = f"{path} must be a directory"
+    with pytest.raises(ValueError, match=re.escape(exp)):
+        w_dir_check(path)
+
+
+def test_write_enabled_dir_read_only(w_dir_check: WDirCheck, tmp_path: Path) -> None:
+    path = tmp_path
+    write = S_IWUSR | S_IWGRP | S_IWOTH
+    path.chmod(path.stat().st_mode & ~write)
+    exp = f"{path} is read-only"
+    try:
+        with pytest.raises(ValueError, match=re.escape(exp)):
+            w_dir_check(path)
+    finally:
+        path.chmod(path.stat().st_mode | write)
+
+
+def test_write_enabled_dir_cannot_create(
+    w_dir_check: WDirCheck, tmp_path: Path
+) -> None:
+    path = tmp_path / "d"
+    write = S_IWUSR | S_IWGRP | S_IWOTH
+    tmp_path.chmod(tmp_path.stat().st_mode & ~write)
+    exp = f"cannot create directory {path} due to [Errno 13] Permission denied:"
+    try:
+        with pytest.raises(ValueError, match=re.escape(exp)):
+            w_dir_check(path)
+    finally:
+        tmp_path.chmod(tmp_path.stat().st_mode | write)


### PR DESCRIPTION
This allows users to run flamegraph (and other) dumps on a test case
run.

Signed-off-by: Bernát Gábor <gaborjbernat@gmail.com>

Resolves #10.