### PR TITLE
Allow specifying the bin path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ MEMORY PROBLEMS demo/test_ok.py::test_memory_exceed
 - `--hide-memray-summary` - hide the memray summary at the end of the execution
 - `--memray-bin-path` - path where to write the memray binary dumps (by default a
   temporary folder)
+- `--memray-bin-prefix` - prefix to use for the binary dump (by default a random UUID4 hex)
 
 ## Configuration - INI
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -18,6 +18,9 @@ The complete list of command line options is:
   ``--memray-bin-path``
     Path where to write the memray binary dumps (by default a temporary folder).
 
+  ``--memray-bin-prefix``
+    Prefix to use for the binary dump (by default a random UUID4 hex)
+
 .. tab:: Config file options
 
   ``memray(bool)``

--- a/docs/news/28.feature.rst
+++ b/docs/news/28.feature.rst
@@ -1,0 +1,3 @@
+Allow specifying the prefix used for ``-memray-bin-path`` dumps via the
+``-memray-bin-prefix`` (and if specified and file already exists will be recreated) -
+by :user:`gaborbernat`.

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -341,6 +341,7 @@ def test_bin_path(pytester: Pytester) -> None:
         "H-magic-test_a.py-test_a.bin",
         "H-magic-test_a.py-test_b[1].bin",
     }
+
     output = result.stdout.str()
     assert f"Created 3 binary dumps at {dump} with prefix H" in output
 

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -341,3 +341,29 @@ def test_bin_path(pytester: Pytester) -> None:
         "H-magic-test_a.py-test_a.bin",
         "H-magic-test_a.py-test_b[1].bin",
     }
+    output = result.stdout.str()
+    assert f"Created 3 binary dumps at {dump} with prefix H" in output
+
+
+@pytest.mark.parametrize("override", [True, False])
+def test_bin_path_prefix(pytester: Pytester, override: bool) -> None:
+    py = """
+    import pytest
+    def test_t():
+        assert [1]
+    """
+    pytester.makepyfile(test_a=py)
+
+    bin_path = pytester.path / "p-test_a.py-test_t.bin"
+    if override:
+        bin_path.write_bytes(b"")
+
+    args = ["--memray", "--memray-bin-path", str(pytester.path)]
+    args.extend(["--memray-bin-prefix", "p"])
+    result = pytester.runpytest(*args)
+    res = list(pytester.path.iterdir())
+
+    assert res
+
+    assert result.ret == ExitCode.OK
+    assert bin_path.exists()


### PR DESCRIPTION
And if set recreate it if already exists. Print the number of dumps
generated in the summary.

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>

Resolves #28.