### PR TITLE
Declare Python 3.11 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development :: Debuggers",
 ]


### PR DESCRIPTION
**Describe your changes**
The Python versions badge in the README is missing Python 3.11, and I believe this is what's needed to add it.

**Testing performed**
None whatsoever 😄 