### PR TITLE
Fix incompatibility with the 'flaky' plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ optional-dependencies.lint = [
 optional-dependencies.test = [
   "covdefaults>=2.2",
   "pytest>=7.1.2",
-  "coverage>=6.4.4"
+  "coverage>=6.4.4",
+  "flaky>=3.7.0",
 ]
 dynamic = ["version"]
 classifiers = [

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -181,12 +181,12 @@ def test_memray_report(pytester: Pytester) -> None:
 
     assert "results for test_memray_report.py::test_foo" in output
     assert "Total memory allocated: 2.0KiB" in output
-    assert "valloc:src/memray/_memray_test_utils.pyx" in output
+    assert "valloc:" in output
     assert "-> 2.0KiB" in output
 
     assert "results for test_memray_report.py::test_bar" in output
     assert "Total memory allocated: 1.0KiB" in output
-    assert "valloc:src/memray/_memray_test_utils.pyx" in output
+    assert "valloc:" in output
     assert "-> 1.0KiB" in output
 
 
@@ -223,12 +223,12 @@ def test_memray_report_is_not_shown_if_deactivated(pytester: Pytester) -> None:
 
     assert "results for test_memray_report.py::test_foo" not in output
     assert "Total memory allocated: 2.0KiB" not in output
-    assert "valloc:src/memray/_memray.pyx" not in output
+    assert "valloc:" not in output
     assert "-> 2.0KiB" not in output
 
     assert "results for test_memray_report.py::test_bar" not in output
     assert "Total memory allocated: 1.0KiB" not in output
-    assert "valloc:src/memray/_memray.pyx" not in output
+    assert "valloc:" not in output
     assert "-> 1.0KiB" not in output
 
 


### PR DESCRIPTION
The 'flaky' plugging does some cuestionable activity and forces our
plugin to be called with itself. This causes us to wrap our own test
wrapper and therefore create nested Trackers, which is not allowed.

To fix this, unwrap the test function at the end of the run.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
