### PR TITLE
Make the plugin compatible with pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ optional-dependencies.test = [
   "pytest>=7.1.2",
   "coverage>=6.4.4",
   "flaky>=3.7.0",
+  "pytest-xdist>=3",
 ]
 dynamic = ["version"]
 classifiers = [


### PR DESCRIPTION
The pytest-xdist plugin spawns worker processes that run the tests while
the main process reports the results. As every process has its own copy
of all the plugins, this means that when the main process reports the
final summary, it doesn't have access to the results stored by every
individual test so the plugin is unable to print the summary.

To make ourselves compatible with pytest-xdist, we make the main process
and the workers use a common path to store the metadata and result files
(this is communicated from the main process to the workers by an
environment variable). Then, at report time, if the main process doesn't
have any result data, it will fetch it from this directory instead.

Closes: #2 