### PR TITLE
Ensure tests marked by memray run even if `--memray` is not passed

### DIFF
--- a/docs/news/57.feature.rst
+++ b/docs/news/57.feature.rst
@@ -1,0 +1,1 @@
+Allow to run tests marked with memray markers without having to provide "--memray" in the command line.

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -103,6 +103,16 @@ class Manager:
     def pytest_pyfunc_call(self, pyfuncitem: Function) -> object | None:
         func = pyfuncitem.obj
 
+        markers = {
+            marker.name
+            for marker in pyfuncitem.iter_markers()
+            if marker.name in MARKERS
+        }
+
+        if not markers and not value_or_ini(self.config, "memray"):
+            yield
+            return
+
         def _build_bin_path() -> Path:
             if self._tmp_dir is None:
                 of_id = pyfuncitem.nodeid.replace("::", "-")
@@ -183,7 +193,9 @@ class Manager:
     def pytest_terminal_summary(
         self, terminalreporter: TerminalReporter, exitstatus: ExitCode
     ) -> None:
-        if value_or_ini(self.config, "hide_memray_summary"):
+        if value_or_ini(self.config, "hide_memray_summary") or not value_or_ini(
+            self.config, "memray"
+        ):
             return
 
         terminalreporter.write_line("")
@@ -290,8 +302,6 @@ def value_or_ini(config: Config, key: str) -> object:
 
 
 def pytest_configure(config: Config) -> None:
-    if not value_or_ini(config, "memray"):
-        return
     pytest_memray = Manager(config)
     config.pluginmanager.register(pytest_memray, "memray_manager")
 

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -79,7 +79,7 @@ def test_limit_memory_marker(pytester: Pytester, size: int, outcome: ExitCode) -
     assert result.ret == outcome
 
 
-def test_limit_memory_marker_does_not_work_if_memray_inactive(
+def test_limit_memory_marker_does_work_if_memray_not_passed(
     pytester: Pytester,
 ) -> None:
     pytester.makepyfile(
@@ -97,7 +97,7 @@ def test_limit_memory_marker_does_not_work_if_memray_inactive(
 
     result = pytester.runpytest()
 
-    assert result.ret == ExitCode.OK
+    assert result.ret == ExitCode.TESTS_FAILED
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The fact that the plugin is not registered if `--memray` is not
provided has proven to be a source of confusion and provides a bad
UX.

Closes: #49 