### PR TITLE
Allow to customize the tracebacks one error

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,16 @@ MEMORY PROBLEMS demo/test_ok.py::test_memory_exceed
   temporary folder)
 - `--memray-bin-prefix` - prefix to use for the binary dump (by default a random UUID4
   hex)
+--stacks=STACKS - Show the N stack entries when showing tracebacks of memory allocations
+--native - Show native frames when showing tracebacks of memory allocations (will be slower)
 
 ## Configuration - INI
 
 - `memray(bool)` - activate memray tracking
 - `most-allocations(string)` - show the N tests that allocate most memory (N=0 for all)
 - `hide_memray_summary(bool)` - hide the memray summary at the end of the execution
+- `stacks(int)` - Show the N stack entries when showing tracebacks of memory allocations
+- `native(bool)`- Show native frames when showing tracebacks of memory allocations (will be slower)
 
 ## License
 

--- a/docs/news/58.feature.rst
+++ b/docs/news/58.feature.rst
@@ -1,0 +1,1 @@
+Add two new options that allow to customize the ammount of frames in allocation tracebacks as well as including hybrid stack traces.

--- a/src/pytest_memray/utils.py
+++ b/src/pytest_memray/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import os
 import re
 from argparse import Action
@@ -7,6 +8,8 @@ from argparse import ArgumentParser
 from argparse import Namespace
 from pathlib import Path
 from typing import Sequence
+
+from pytest import Config
 
 
 def sizeof_fmt(num: int | float, suffix: str = "B") -> str:
@@ -43,6 +46,16 @@ def parse_memory_string(mem_str: str) -> float:
     return float(quantity) * UNIT_TO_MULTIPLIER[unit.upper()]
 
 
+def value_or_ini(config: Config, key: str) -> object:
+    value = config.getvalue(key)
+    if value:
+        return value
+    try:
+        return config.getini(key)
+    except (KeyError, ValueError):
+        return value
+
+
 class WriteEnabledDirectoryAction(Action):
     def __call__(
         self,
@@ -67,8 +80,17 @@ class WriteEnabledDirectoryAction(Action):
         setattr(namespace, self.dest, folder)
 
 
+def positive_int(value: str) -> int:
+    the_int = int(value)
+    if the_int <= 0:
+        raise argparse.ArgumentTypeError(f"{value} is an invalid positive int value")
+    return the_int
+
+
 __all__ = [
     "WriteEnabledDirectoryAction",
     "parse_memory_string",
     "sizeof_fmt",
+    "value_or_ini",
+    "positive_int",
 ]


### PR DESCRIPTION
To allow users to get as much information as they need, add two new
options to the command line invocation that allows to:

* Customize how many stacks to show for every allocation.
* Obtain native traces and show the hybrid stack.

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
