### PR TITLE
Do not return our result from the pytest_pyfunc_call wrapper

### DIFF
--- a/docs/news/60.bugfix.rst
+++ b/docs/news/60.bugfix.rst
@@ -1,0 +1,1 @@
+Fix pytest raising ``pytest.PytestReturnNotNoneWarning`` from test decorated with memray markers.

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -150,10 +150,11 @@ class Manager:
 
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> object | None:
+            test_result: object | Any = None
             try:
                 result_file = _build_bin_path()
                 with Tracker(result_file, native_traces=native):
-                    result: object | None = func(*args, **kwargs)
+                    test_result = func(*args, **kwargs)
                 try:
                     metadata = FileReader(result_file).metadata
                 except OSError:
@@ -172,7 +173,7 @@ class Manager:
                 # hook again with whatever is here, which will cause the wrapper
                 # to be wrapped again.
                 pyfuncitem.obj = func
-            return result
+            return test_result
 
         pyfuncitem.obj = wrapper
         yield

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -532,3 +532,20 @@ def test_limit_memory_marker_with_pytest_xdist(
 
     result = pytester.runpytest("--memray", "-n", "2")
     assert result.ret == outcome
+
+
+def test_memray_does_not_raise_warnings(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        import pytest
+        from memray._test import MemoryAllocator
+        allocator = MemoryAllocator()
+
+        @pytest.mark.limit_memory("1MB")
+        def test_memory_alloc_fails():
+            allocator.valloc(1234)
+            allocator.free()
+        """
+    )
+    result = pytester.runpytest("-Werror", "--memray")
+    assert result.ret == ExitCode.OK


### PR DESCRIPTION
Pytest shows a warning if we return something from the
pytest_pyfunc_call wrapper as it interprets this as the test returning a
value. We are incorrecly returning the pytest test result from the
wrapper instead of whatever the test returns.

Closes: #60
