### PR TITLE
Fix long test names with xdist

### DIFF
--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -91,7 +91,7 @@ class Manager:
         path: Path | None = config.getvalue("memray_bin_path")
         self._tmp_dir: None | TemporaryDirectory[str] = None
         if path is None:
-            # Check the MEMRAY_RESULT_PAtH environment variable. If this
+            # Check the MEMRAY_RESULT_PATH environment variable. If this
             # is set, it means that we are running in a worker and the main
             # process has set it so we'll use it as the directory to store
             # the results.
@@ -135,7 +135,7 @@ class Manager:
             return
 
         def _build_bin_path() -> Path:
-            if self._tmp_dir is None:
+            if self._tmp_dir is None and not os.getenv("MEMRAY_RESULT_PATH"):
                 of_id = pyfuncitem.nodeid.replace("::", "-")
                 of_id = of_id.replace(os.sep, "-")
                 name = f"{self._bin_prefix}-{of_id}.bin"

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -470,7 +470,8 @@ def test_memray_report_with_pytest_xdist(pytester: Pytester) -> None:
             allocator.valloc(1024*2)
             allocator.free()
 
-        def test_foo():
+        @pytest.mark.parametrize("param", [("unused",)], ids=["x" * 1024])
+        def test_foo(param):
             allocating_func1()
 
         def test_bar():


### PR DESCRIPTION
This fixes the `OSError` caused by long capture file names in our temporary directory when `--memray-bin-path` is not in use by `pytest-xdist` is.

Relates-to: #68 