### PR TITLE
Clarify that reported allocations are at the high watermark

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,7 +22,7 @@ pytest:
 Allocation tracking
 ~~~~~~~~~~~~~~~~~~~
 
-By default, the plugin will track allocations in all tests. This information is
+By default, the plugin will track allocations at the high watermark in all tests. This information is
 reported after tests run ends:
 
 .. command-output:: env COLUMNS=92 pytest --memray demo

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -282,7 +282,7 @@ class Manager:
         terminalreporter: TerminalReporter,
     ) -> None:
         writeln = terminalreporter.write_line
-        writeln(f"Allocations results for {test_id}")
+        writeln(f"Allocation results for {test_id} at the high watermark")
         writeln("")
         writeln(f"\t 📦 Total memory allocated: {sizeof_fmt(metadata.peak_memory)}")
         writeln(f"\t 📏 Total allocations: {metadata.total_allocations}")


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #8*

Clarify that the reported allocations are at the high watermark, both in the docs and in the printed report.

**Testing performed**
N/A

