### PR TITLE
Relax the sizes in the 'test_limit_memory_marker_with_pytest_xdist' test

### DIFF
--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -504,10 +504,9 @@ def test_memray_report_with_pytest_xdist(pytester: Pytester) -> None:
 @pytest.mark.parametrize(
     "size, outcome",
     [
-        (1024 * 5, ExitCode.TESTS_FAILED),
-        (1024 * 2, ExitCode.TESTS_FAILED),
-        (1024 * 2 - 1, ExitCode.OK),
-        (1024 * 1, ExitCode.OK),
+        (1024 * 20, ExitCode.TESTS_FAILED),
+        (1024 * 10, ExitCode.TESTS_FAILED),
+        (1024, ExitCode.OK),
     ],
 )
 def test_limit_memory_marker_with_pytest_xdist(
@@ -519,12 +518,12 @@ def test_limit_memory_marker_with_pytest_xdist(
         from memray._test import MemoryAllocator
         allocator = MemoryAllocator()
 
-        @pytest.mark.limit_memory("2KB")
+        @pytest.mark.limit_memory("10KB")
         def test_memory_alloc_fails():
             allocator.valloc({size})
             allocator.free()
 
-        @pytest.mark.limit_memory("2KB")
+        @pytest.mark.limit_memory("10KB")
         def test_memory_alloc_fails_2():
             allocator.valloc({size})
             allocator.free()


### PR DESCRIPTION
When using `pytest-xdist` there are some extra allocations that the
plugin does that make it quite difficult to test values for the `limit`
decorator that are close to the numeric limit. In particular this is a
sample list of allocations in Python 3.11 when the plugin is active:

```
List of allocations:
    - 628.0B allocated here:
        channel_data:/lib/python3.11/site-packages/execnet/gateway_base.py:476
    - 534.0B allocated here:
        _local_receive:/lib/python3.11/site-packages/execnet/gateway_base.py:856
    - 772.0B allocated here:
        handle_command:/lib/python3.11/site-packages/xdist/remote.py:128
    - 1.0KiB allocated here:
        valloc:/lib/python3.11/site-packages/memray/_test.py:44
    - 862.0B allocated here:
        _thread_receiver:/lib/python3.11/site-packages/execnet/gateway_base.py:969
```

The only one the test cares about is the one made using `valloc`, but
unlike in the `memray` test suite we cannot filter them in the tests, so
we need to make the allocation sizes bigger and remove the tests that
are checking exactly in the limit.
