### PR TITLE
[Docs] Fix the bulleted lists in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ MEMORY PROBLEMS demo/test_ok.py::test_memory_exceed
   temporary folder)
 - `--memray-bin-prefix` - prefix to use for the binary dump (by default a random UUID4
   hex)
---stacks=STACKS - Show the N stack entries when showing tracebacks of memory allocations
---native - Show native frames when showing tracebacks of memory allocations (will be slower)
---trace-python-allocators - Record allocations made by the Pymalloc allocator (will be slower)
+- `--stacks=STACKS` - Show the N stack entries when showing tracebacks of memory allocations
+- `--native` - Show native frames when showing tracebacks of memory allocations (will be slower)
+- `--trace-python-allocators` - Record allocations made by the Pymalloc allocator (will be slower)
 
 ## Configuration - INI
 


### PR DESCRIPTION
Fix the bulleted lists in README.md

## Before
![image](https://github.com/bloomberg/pytest-memray/assets/32220263/bcfff21e-51c6-4c71-8f4c-5c2e05aa5cab)

## After
![image](https://github.com/bloomberg/pytest-memray/assets/32220263/ee5344f2-f72a-4f62-afdc-931c4518d7b6)
