### PR TITLE
Add a new --fail-on-increase option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ MEMORY PROBLEMS demo/test_ok.py::test_memory_exceed
 - `--stacks=STACKS` - Show the N stack entries when showing tracebacks of memory allocations
 - `--native` - Show native frames when showing tracebacks of memory allocations (will be slower)
 - `--trace-python-allocators` - Record allocations made by the Pymalloc allocator (will be slower)
+- `--fail-on-increase` - Fail a test with the `limit_memory`` marker if it uses
+  more memory than its last successful run
 
 ## Configuration - INI
 
@@ -105,7 +107,9 @@ MEMORY PROBLEMS demo/test_ok.py::test_memory_exceed
 - `hide_memray_summary(bool)` - hide the memray summary at the end of the execution
 - `stacks(int)` - Show the N stack entries when showing tracebacks of memory allocations
 - `native(bool)`- Show native frames when showing tracebacks of memory allocations (will be slower)
-- `trace_python_allocators` - Record allocations made by the Pymalloc allocator (will be slower)
+- `trace_python_allocators(bool)` - Record allocations made by the Pymalloc allocator (will be slower)
+- `fail-on-increase(bool)` - Fail a test with the `limit_memory` marker if it
+  uses more memory than its last successful run
 
 ## License
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,6 +29,9 @@ The complete list of command line options is:
 
   ``--trace-python-allocators``
     Record allocations made by the Pymalloc allocator (will be slower)
+  
+  ``--fail-on-increase``
+    Fail a test with the limit_memory marker if it uses more memory than its last successful run
 
 .. tab:: Config file options
 
@@ -49,3 +52,6 @@ The complete list of command line options is:
 
   ``trace_python_allocators(bool)``
     Record allocations made by the Pymalloc allocator (will be slower)
+
+  ``--fail-on-increase(bool)``
+    Fail a test with the limit_memory marker if it uses more memory than its last successful run

--- a/docs/news/91.feature.rst
+++ b/docs/news/91.feature.rst
@@ -1,0 +1,1 @@
+Add a new --fail-on-increase option that fails a test with the ``limit_memory`` marker if it uses more memory than its last successful run.

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -52,6 +52,7 @@ class PluginFn(Protocol):
         *args: Any,
         _result_file: Path,
         _config: Config,
+        _test_id: str,
         **kwargs: Any,
     ) -> SectionMetadata | None:
         ...
@@ -237,6 +238,7 @@ class Manager:
                 **marker.kwargs,
                 _result_file=result.result_file,
                 _config=self.config,
+                _test_id=item.nodeid,
             )
             if res:
                 report.outcome = "failed"
@@ -384,6 +386,12 @@ def pytest_addoption(parser: Parser) -> None:
         default=False,
         help="Record allocations made by the Pymalloc allocator (will be slower)",
     )
+    group.addoption(
+        "--fail-on-increase",
+        action="store_true",
+        default=False,
+        help="Fail a test with the limit_memory marker if it uses more memory than its last successful run",
+    )
 
     parser.addini("memray", "Activate pytest.ini setting", type="bool")
     parser.addini(
@@ -405,6 +413,11 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         "trace_python_allocators",
         help="Record allocations made by the Pymalloc allocator (will be slower)",
+        type="bool",
+    )
+    parser.addini(
+        "fail-on-increase",
+        help="Fail a test with the limit_memory marker if it uses more memory than its last successful run",
         type="bool",
     )
     help_msg = "Show the N tests that allocate most memory (N=0 for all)"


### PR DESCRIPTION
As requested from some users, add a new --fail-on-increase option that
makes the test run fail if the memory usage increases from previous runs
in tests marked with "limit_memory".

*Issue number of the reported bug or feature request: #7 

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.

closes: #7
