### PR TITLE
Fix --most-allocations with the value of 0

### DIFF
--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -287,6 +287,8 @@ class Manager:
         )
 
         max_results = cast(int, value_or_ini(self.config, "most_allocations"))
+        if max_results == 0:
+            max_results = len(total_sizes)
 
         for test_id, total_size in total_sizes.most_common(max_results):
             result = self.results[test_id]

--- a/src/pytest_memray/utils.py
+++ b/src/pytest_memray/utils.py
@@ -48,7 +48,7 @@ def parse_memory_string(mem_str: str) -> float:
 
 def value_or_ini(config: Config, key: str) -> object:
     value = config.getvalue(key)
-    if value:
+    if value is not None:
         return value
     try:
         return config.getini(key)


### PR DESCRIPTION
In the docs we say that a value of 0 will show all entries but
currently the plugin crashes because it interprets the value of 0 as a
string and is not properly propagated to show all entries.

*Issue number of the reported bug or feature request: #46

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
