### PR TITLE
Drop `# type: ignore` comments for `@hookimpl`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    # At 12:00 UTC on every day-of-month
+    - cron: "0 12 */1 * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -7,7 +7,7 @@ on:
     types:
       - published
   schedule:
-    # At 12:00 on every day-of-month
+    # At 12:00 UTC on every day-of-month
     - cron: "0 12 */1 * *"
 
 concurrency:

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -133,7 +133,7 @@ class Manager:
         self.result_metadata_path = self.result_path / "metadata"
         self.result_metadata_path.mkdir(exist_ok=True, parents=True)
 
-    @hookimpl(hookwrapper=True)  # type: ignore[misc] # Untyped decorator
+    @hookimpl(hookwrapper=True)
     def pytest_unconfigure(self, config: Config) -> Generator[None, None, None]:
         yield
         if self._tmp_dir is not None:
@@ -141,7 +141,7 @@ class Manager:
         if os.environ.get("MEMRAY_RESULT_PATH"):
             del os.environ["MEMRAY_RESULT_PATH"]
 
-    @hookimpl(hookwrapper=True)  # type: ignore[misc] # Untyped decorator
+    @hookimpl(hookwrapper=True)
     def pytest_pyfunc_call(self, pyfuncitem: Function) -> object | None:
         func = pyfuncitem.obj
 
@@ -212,7 +212,7 @@ class Manager:
         pyfuncitem.obj = wrapper
         yield
 
-    @hookimpl(hookwrapper=True)  # type: ignore[misc] # Untyped decorator
+    @hookimpl(hookwrapper=True)
     def pytest_runtest_makereport(
         self, item: Item, call: CallInfo[None]
     ) -> Generator[None, TestReport | None, TestReport | None]:
@@ -245,7 +245,7 @@ class Manager:
                 outcome.force_result(report)
         return None
 
-    @hookimpl(hookwrapper=True, trylast=True)  # type: ignore[misc] # Untyped decorator
+    @hookimpl(hookwrapper=True, trylast=True)
     def pytest_report_teststatus(
         self, report: CollectReport | TestReport
     ) -> Generator[None, TestReport, None]:
@@ -257,7 +257,7 @@ class Manager:
             outcome.force_result(("failed", "M", "MEMORY PROBLEMS"))
         return None
 
-    @hookimpl  # type: ignore[misc] # Untyped decorator
+    @hookimpl
     def pytest_terminal_summary(
         self, terminalreporter: TerminalReporter, exitstatus: ExitCode
     ) -> None:

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -369,11 +369,11 @@ def test_memray_report_limit(pytester: Pytester) -> None:
         allocator = MemoryAllocator()
 
         def allocating_func1():
-            allocator.valloc(1024)
+            allocator.valloc(1024*1024)
             allocator.free()
 
         def allocating_func2():
-            allocator.valloc(1024*2)
+            allocator.valloc(1024*1024*2)
             allocator.free()
 
         def test_foo():


### PR DESCRIPTION
These no longer trigger a warning with the current versions of mypy,
pytest, and pluggy. It looks as though these calls have been typed since
pluggy 1.2.0, which was released 3 months ago.

We didn't notice this because our lint checks weren't scheduled to run on a schedule. This PR fixes that as well.