### PR TITLE
Use aggregated capture files

### DIFF
--- a/docs/news/107.feature.rst
+++ b/docs/news/107.feature.rst
@@ -1,0 +1,1 @@
+Use aggregated capture files, reducing the amount of temporary disk space required in order to run tests.

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -21,6 +21,7 @@ from typing import Protocol
 
 from _pytest.terminal import TerminalReporter
 from memray import AllocationRecord
+from memray import FileFormat
 from memray import FileReader
 from memray import Metadata
 from memray import Tracker
@@ -188,6 +189,7 @@ class Manager:
                     result_file,
                     native_traces=native,
                     trace_python_allocators=trace_python_allocators,
+                    file_format=FileFormat.AGGREGATED_ALLOCATIONS,
                 ):
                     test_result = func(*args, **kwargs)
                 try:

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY
 from unittest.mock import patch
 
 import pytest
+from memray import FileFormat
 from memray import Tracker
 from pytest import ExitCode
 from pytest import Pytester
@@ -225,7 +226,10 @@ def test_memray_report_native(native: bool, pytester: Pytester) -> None:
 
     output = result.stdout.str()
     mock.assert_called_once_with(
-        ANY, native_traces=native, trace_python_allocators=False
+        ANY,
+        native_traces=native,
+        trace_python_allocators=False,
+        file_format=FileFormat.AGGREGATED_ALLOCATIONS,
     )
 
     if native:
@@ -268,7 +272,10 @@ def test_memray_report_python_allocators(
 
     output = result.stdout.str()
     mock.assert_called_once_with(
-        ANY, native_traces=False, trace_python_allocators=trace_python_allocators
+        ANY,
+        native_traces=False,
+        trace_python_allocators=trace_python_allocators,
+        file_format=FileFormat.AGGREGATED_ALLOCATIONS,
     )
 
     if trace_python_allocators:


### PR DESCRIPTION
This reduces the amount of temporary disk space needed while running tests.
