### PR TITLE
Improve tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { "py": "3.11", "tox_env": "py311-cov" }
+          - { "py": "3.12", "tox_env": "py312-cov" }
+          - { "py": "3.12", "tox_env": "py312" }
           - { "py": "3.11", "tox_env": "py311" }
           - { "py": "3.10", "tox_env": "py310" }
           - { "py": "3.9", "tox_env": "py39" }

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -689,10 +689,9 @@ def test_leak_marker(pytester: Pytester, size: int, outcome: ExitCode) -> None:
 @pytest.mark.parametrize(
     "size, outcome",
     [
-        (1, ExitCode.OK),
-        (1024 * 1 / 10, ExitCode.OK),
-        (1024 * 1, ExitCode.TESTS_FAILED),
-        (1024 * 10, ExitCode.TESTS_FAILED),
+        (4 * 1024, ExitCode.OK),
+        (0.4 * 1024 * 1024, ExitCode.OK),
+        (4 * 1024 * 1024, ExitCode.TESTS_FAILED),
     ],
 )
 def test_leak_marker_in_a_thread(
@@ -708,7 +707,7 @@ def test_leak_marker_in_a_thread(
             for _ in range(10):
                 allocator.valloc({size})
                 # No free call here
-        @pytest.mark.limit_leaks("5KB")
+        @pytest.mark.limit_leaks("20MB")
         def test_memory_alloc_fails():
             t = threading.Thread(target=allocating_func)
             t.start()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist =
-    py310-cov
+    py312-cov
+    py312
+    py311
     py310
     py39
     py38
@@ -29,7 +31,7 @@ allowlist_externals =
 package = wheel
 wheel_build_env = .pkg
 
-[testenv:py310-cov]
+[testenv:py312-cov]
 commands =
     make coverage
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ description =
     cov: with coverage
 passenv =
     CI
-    PYTEST_
-    VIRTUALENV_
+    PYTEST_*
+    VIRTUALENV_*
 setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
     VIRTUALENV_NO_SETUPTOOLS = true


### PR DESCRIPTION
Fix a few different issues that I noticed while working on #103:

1. The `PYTEST_ADDOPTS` environment variable wasn't being passed through to pytest by tox, apparently due to our config file not using a wildcard where we meant to.
2. Tox wasn't exercising Python 3.11 or 3.12 by default (even though our CI exercised them)
3. One of our tests would fail if run in isolation due to libpthread "leaking" memory by saving a thread and its stack for later reuse.