### PR TITLE
Ensure our histogram uses a non-zero step

### DIFF
--- a/docs/news/113.bugfix.rst
+++ b/docs/news/113.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the generation of histograms when the tests performed zero-byte allocations.

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -91,7 +91,7 @@ def cli_hist(data: Iterable[float], bins: int, *, log_scale: bool = True) -> str
     high = max(data)
     data_bins = histogram(data, low=low, high=high, bins=bins)
     bar_indexes = (int(elem * (len(bars) - 1) / max(data_bins)) for elem in data_bins)
-    result = " ".join(bars[bar_index] for bar_index in bar_indexes)
+    result = "".join(bars[bar_index] for bar_index in bar_indexes)
     return result
 
 

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -78,7 +78,7 @@ def histogram(
     [0, 0, 0, 0, 1, 0, 0, 1, 3, 2]
 
     """
-    step = ((high - low) / bins) or low
+    step = ((high - low) / bins) or low or 1
     dist = collections.Counter((x - low) // step for x in iterable)
     return [dist[b] for b in range(bins)]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ import pytest
 
 from pytest_memray.utils import WriteEnabledDirectoryAction
 from pytest_memray.utils import parse_memory_string
+from pytest_memray.plugin import cli_hist
 
 
 @pytest.mark.parametrize(
@@ -123,3 +124,25 @@ def test_write_enabled_dir_cannot_create(
             w_dir_check(path)
     finally:
         tmp_path.chmod(tmp_path.stat().st_mode | write)
+
+
+def test_histogram_with_zero_byte_allocations():
+    # GIVEN
+    allocations = [0, 100, 990, 1000, 50000]
+
+    # WHEN
+    histogram = cli_hist(allocations, bins=5)
+
+    # THEN
+    assert histogram == "▄   ▄ █ ▄"
+
+
+def test_histogram_with_only_zero_byte_allocations():
+    # GIVEN
+    allocations = [0, 0, 0, 0]
+
+    # WHEN
+    histogram = cli_hist(allocations, bins=5)
+
+    # THEN
+    assert histogram == "█        "

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -134,7 +134,7 @@ def test_histogram_with_zero_byte_allocations():
     histogram = cli_hist(allocations, bins=5)
 
     # THEN
-    assert histogram == "▄   ▄ █ ▄"
+    assert histogram == "▄ ▄█▄"
 
 
 def test_histogram_with_only_zero_byte_allocations():
@@ -145,4 +145,4 @@ def test_histogram_with_only_zero_byte_allocations():
     histogram = cli_hist(allocations, bins=5)
 
     # THEN
-    assert histogram == "█        "
+    assert histogram == "█    "


### PR DESCRIPTION
When all allocations are the same size, we were falling back to the size of the smallest allocation as our step for generating histogram buckets. When the smallest allocation was zero bytes, that would lead to a division by zero and an exception.

Fix this by falling back to 1 instead of the size of the smallest allocation. This will never lead to a zero division error, and still puts every element in the same bucket because they're all equal (otherwise we wouldn't have needed the fallback).

Closes #93 