### PR TITLE
Cooperate with anyio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ optional-dependencies.lint = [
   "mypy==0.991",
 ]
 optional-dependencies.test = [
+  "anyio>=4.4.0",
   "covdefaults>=2.2.2",
   "pytest>=7.2",
   "coverage>=7.0.5",


### PR DESCRIPTION
`anyio` allows running `async def` test functions, but the wrapper installed by Memray to add tracking around the test function breaks `anyio`'s detection.

Work around this by using an `async def` wrapper when the function being wrapped is a coroutine function.

Closes #119