### PR TITLE
Add object tracking functionality for Python 3.13.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
-      - name: setup Python 3.11
+      - name: setup Python 3.14
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.14"
       - name: install tox
         run: python -m pip install tox
       - name: install docs dependencies

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,6 +6,10 @@ pytest-memray API
 Types
 -----
 
+.. autoclass:: LeakedObjectsFilterFunction()
+   :members: __call__
+   :show-inheritance:
+
 .. autoclass:: LeaksFilterFunction()
    :members: __call__
    :show-inheritance:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -152,3 +152,37 @@ that can be used to enforce additional checks and validations on tests.
        Because of this, you will almost certainly need to allow some small amount of
        leaked memory per call stack, or use the ``filter_fn`` argument to filter out
        false-positive leak reports based on the call stack they're associated with.
+
+
+.. py:function:: pytest.mark.track_leaked_objects()
+
+    Fail the execution of the test if any Python objects created while the test body
+    runs are still alive at the end of the test.
+
+    This is only possible for Python 3.13.3 and newer. Using this marker with older
+    Python versions will cause an error during test collection. You can use
+    ``pytest.mark.skipif`` to prevent the test from running if the Python version is too
+    old, or you can conditionally add the ``limit_leaked_objects`` marker only if the
+    Python version is new enough.
+
+    .. warning::
+       It is **very** challenging to write tests that do not "leak" memory in some way,
+       due to circumstances beyond your control.
+
+       There are many caches inside the Python interpreter itself. Just a few examples:
+
+       - The `re` module caches compiled regexes.
+       - The `logging` module caches whether a given log level is active for
+         a particular logger the first time you try to log something at that level.
+
+       There are many more such caches. Also, within pytest, any message that you log or
+       print is captured, so that it can be included in the output if the test fails.
+
+       Memray sees these all as "leaks", because something was allocated while the test
+       ran and it was not freed by the time the test body finished. We don't know that
+       it's due to an implementation detail of the standard library or pytest that the
+       memory wasn't freed. Morever, because these caches are implementation details,
+       they can change from one Python version to another.
+
+       Because of this, you will need to very carefully design your test to avoid
+       objects being cached.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -154,7 +154,7 @@ that can be used to enforce additional checks and validations on tests.
        false-positive leak reports based on the call stack they're associated with.
 
 
-.. py:function:: pytest.mark.track_leaked_objects()
+.. py:function:: pytest.mark.limit_leaked_objects(filter_fn: LeakedObjectsFilterFunction | None = None)
 
     Fail the execution of the test if any Python objects created while the test body
     runs are still alive at the end of the test.
@@ -164,6 +164,13 @@ that can be used to enforce additional checks and validations on tests.
     ``pytest.mark.skipif`` to prevent the test from running if the Python version is too
     old, or you can conditionally add the ``limit_leaked_objects`` marker only if the
     Python version is new enough.
+
+    The marker takes an optional keyword-only argument ``filter_fn`` that can be used to
+    ignore certain leaked objects. This argument represents a filtering function that
+    will be called once for each object leaked by the test body. If it returns *True*,
+    leaks of that object will be included in the final report. If it returns *False*,
+    that leaked object will be ignored. If all leaks are ignored, the test will not
+    fail. This can be used to discard any known false positives.
 
     .. warning::
        It is **very** challenging to write tests that do not "leak" memory in some way,
@@ -185,4 +192,5 @@ that can be used to enforce additional checks and validations on tests.
        they can change from one Python version to another.
 
        Because of this, you will need to very carefully design your test to avoid
-       objects being cached.
+       objects being cached, or use the ``filter_fn`` argument to filter out
+       false-positive leak reports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ maintainers = [
 requires-python = ">=3.8"
 dependencies = [
   "pytest>=7.2",
-  "memray>=1.12",
+  "memray>=1.19.1",
 ]
 dynamic = ["version"]
 classifiers = [
@@ -81,6 +81,11 @@ run.dynamic_context = "test_function"
 run.source = ["pytest_memray", "tests"]
 run.plugins = ["covdefaults"]
 run.parallel = true
+# The object tracking feature only runs on Python 3.13.3+, which is not the
+# interpreter used by the coverage job, so it would otherwise be reported as
+# uncovered. The feature code carries "# pragma: no cover" and its test module
+# is omitted here; both are intentional, not an oversight.
+run.omit = ["tests/test_object_tracking.py"]
 report.fail_under = 97
 html.show_contexts = true
 html.skip_covered = false

--- a/src/pytest_memray/__init__.py
+++ b/src/pytest_memray/__init__.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from ._version import __version__ as __version__
+from .marks import LeakedObjectsFilterFunction
 from .marks import LeaksFilterFunction
 from .marks import Stack
 from .marks import StackFrame
 
 __all__ = [
     "__version__",
+    "LeakedObjectsFilterFunction",
     "LeaksFilterFunction",
     "Stack",
     "StackFrame",

--- a/src/pytest_memray/marks.py
+++ b/src/pytest_memray/marks.py
@@ -50,10 +50,11 @@ class Stack:
 class LeaksFilterFunction(Protocol):
     """A callable that can decide whether to ignore some memory leaks.
 
-    This can be used to suppress leak reports from locations that are known to
-    leak. For instance, you might know that objects of a certain type are
-    cached by the code you're invoking, and so you might want to ignore all
-    reports of leaked memory allocated below that type's constructor.
+    This can be used with the `.limit_leaks` marker to suppress leak reports
+    from locations that are known to leak. For instance, you might know that
+    objects of a certain type are cached by the code you're invoking, and so
+    you might want to ignore all reports of leaked memory allocated below that
+    type's constructor.
 
     You can provide any callable with the following signature as the
     ``filter_fn`` keyword argument for the `.limit_leaks` marker:
@@ -64,6 +65,27 @@ class LeaksFilterFunction(Protocol):
 
         Return ``True`` if you want the leak to be reported, or ``False`` if
         you want it to be suppressed.
+        """
+        ...
+
+
+class LeakedObjectsFilterFunction(Protocol):
+    """A callable that can decide whether it's OK for some object to be leaked.
+
+    This can be used with the `.limit_leaked_objects` marker to suppress leak
+    reports for objects that are known to leak. For instance, you might know
+    that objects of a certain type are cached by the code you're invoking, and
+    so you might want to ignore all reports of leaked objects of that type.
+
+    You can provide any callable with the following signature as the
+    ``filter_fn`` keyword argument for the `.limit_leaked_objects` marker:
+    """
+
+    def __call__(self, obj: object) -> bool:
+        """Return whether a leak of this object should be reported.
+
+        Return ``True`` if you want the leak to be reported (causing the test
+        to fail), or ``False`` if you want it to be suppressed.
         """
         ...
 
@@ -339,13 +361,23 @@ class _TrackedObjectsInfo:  # pragma: no cover
         return "\n".join(text_lines)
 
 
-def track_leaked_objects(  # pragma: no cover
+def limit_leaked_objects(  # pragma: no cover
+    *,
+    filter_fn: Optional[LeakedObjectsFilterFunction] = None,
     _result_file: Path,
     _config: Config,
     _test_id: str,
     _surviving_objects: list[object] | None = None,
 ) -> _TrackedObjectsInfo | None:
     """Track objects that survive the test execution."""
+
+    if _surviving_objects is None:
+        _surviving_objects = []
+
+    _surviving_objects = [
+        obj for obj in _surviving_objects if not filter_fn or filter_fn(obj)
+    ]
+
     if not _surviving_objects:
         return None
 

--- a/src/pytest_memray/marks.py
+++ b/src/pytest_memray/marks.py
@@ -267,9 +267,95 @@ def limit_leaks(
     )
 
 
+# How many distinct types and individual objects to show in a leak report,
+# and the maximum length of each object's repr() before it is truncated.
+_MAX_REPORTED_TYPES = 10
+_MAX_REPORTED_SAMPLES = 10
+_MAX_REPR_LEN = 100
+
+
+@dataclass
+class _TrackedObjectsInfo:  # pragma: no cover
+    """Type that holds information about objects that survived tracking."""
+
+    surviving_objects: list[object]
+
+    @property
+    def section(self) -> PytestSection:
+        """Return a tuple in the format expected by section reporters."""
+        body = self._generate_section_text()
+        return (
+            "memray-tracked-objects",
+            "List of leaked objects:\n" + body,
+        )
+
+    @property
+    def long_repr(self) -> str:
+        """Generate a longrepr user-facing error message."""
+        return f"Test leaked {len(self.surviving_objects)} objects"
+
+    def _generate_section_text(self) -> str:
+        """Generate a text summary of leaked objects."""
+        from collections import Counter
+
+        # Group objects by type
+        type_counts = Counter(type(obj).__name__ for obj in self.surviving_objects)
+
+        text_lines = []
+        padding = " " * 4
+
+        # Show top object types that leaked
+        text_lines.append(
+            f"{padding}Object types that leaked (total: {len(self.surviving_objects)} objects):"
+        )
+        top_types = type_counts.most_common(_MAX_REPORTED_TYPES)
+        max_count_len = max(len(str(count)) for _, count in top_types)
+        for obj_type, count in top_types:
+            text_lines.append(
+                f"{padding*2}- {count:>{max_count_len}} {obj_type} instance(s)"
+            )
+        if len(type_counts) > _MAX_REPORTED_TYPES:
+            text_lines.append(
+                f"{padding*2}... and {len(type_counts) - _MAX_REPORTED_TYPES} more types"
+            )
+
+        # Show a sample of the actual objects
+        text_lines.append(f"\n{padding}Sample of leaked objects:")
+        for obj in self.surviving_objects[:_MAX_REPORTED_SAMPLES]:
+            try:
+                obj_repr = repr(obj)
+            except Exception:
+                obj_repr = "<repr failed>"
+
+            # Truncate long representations
+            if len(obj_repr) > _MAX_REPR_LEN:
+                obj_repr = obj_repr[: _MAX_REPR_LEN - 3] + "..."
+            text_lines.append(f"{padding*2}- {type(obj).__name__}: {obj_repr}")
+
+        if len(self.surviving_objects) > _MAX_REPORTED_SAMPLES:
+            extra = len(self.surviving_objects) - _MAX_REPORTED_SAMPLES
+            text_lines.append(f"{padding*2}... and {extra} more")
+
+        return "\n".join(text_lines)
+
+
+def track_leaked_objects(  # pragma: no cover
+    _result_file: Path,
+    _config: Config,
+    _test_id: str,
+    _surviving_objects: list[object] | None = None,
+) -> _TrackedObjectsInfo | None:
+    """Track objects that survive the test execution."""
+    if not _surviving_objects:
+        return None
+
+    return _TrackedObjectsInfo(surviving_objects=_surviving_objects)
+
+
 __all__ = [
     "limit_memory",
     "limit_leaks",
+    "limit_leaked_objects",
     "LeaksFilterFunction",
     "Stack",
     "StackFrame",

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import collections
 import functools
+import gc
 import inspect
 import math
 import os
 import pickle
+import sys
 import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -34,10 +36,12 @@ from pytest import Function
 from pytest import Item
 from pytest import Parser
 from pytest import TestReport
+from pytest import UsageError
 from pytest import hookimpl
 
 from .marks import limit_memory
 from .marks import limit_leaks
+from .marks import limit_leaked_objects
 from .utils import WriteEnabledDirectoryAction
 from .utils import positive_int
 from .utils import sizeof_fmt
@@ -62,6 +66,7 @@ class PluginFn(Protocol):
 MARKERS = {
     "limit_memory": limit_memory,
     "limit_leaks": limit_leaks,
+    "limit_leaked_objects": limit_leaked_objects,
 }
 
 N_TOP_ALLOCS = 5
@@ -108,6 +113,7 @@ class Result:
 class Manager:
     def __init__(self, config: Config) -> None:
         self.results: dict[str, Result] = {}
+        self.surviving_objects: dict[str, list[object]] = {}  # Store separately
         self.config = config
         path: Path | None = config.getvalue("memray_bin_path")
         self._tmp_dir: None | TemporaryDirectory[str] = None
@@ -140,6 +146,23 @@ class Manager:
             self._tmp_dir.cleanup()
         if os.environ.get("MEMRAY_RESULT_PATH"):
             del os.environ["MEMRAY_RESULT_PATH"]
+
+    @hookimpl
+    def pytest_collection_modifyitems(self, config: Config, items: list[Item]) -> None:
+        # The limit_leaked_objects marker requires Python 3.13.3+. Fail at
+        # collection time (as documented) rather than letting the test run and
+        # error during the call phase.
+        if sys.version_info >= (3, 13, 3):
+            return
+        for item in items:  # pragma: no cover
+            if any(
+                marker.name == "limit_leaked_objects" for marker in item.iter_markers()
+            ):
+                raise UsageError(
+                    "The limit_leaked_objects marker requires Python 3.13.3 "
+                    "or later. Current version: "
+                    f"{'.'.join(map(str, sys.version_info[:3]))}"
+                )
 
     @hookimpl(hookwrapper=True)
     def pytest_pyfunc_call(self, pyfuncitem: Function) -> Iterable[None]:
@@ -178,8 +201,12 @@ class Manager:
         if markers and "limit_leaks" in markers:
             native = trace_python_allocators = True
 
+        # Object tracking requires Python 3.13.3+; this is enforced at
+        # collection time (see pytest_collection_modifyitems).
+        track_objects = "limit_leaked_objects" in markers
+
         @contextmanager
-        def memory_reporting() -> Generator[None, None, None]:
+        def memory_reporting() -> Generator[Tuple[Tracker, bool], None, None]:
             # Restore the original function. This is needed because some
             # pytest plugins (e.g. flaky) will call our pytest_pyfunc_call
             # hook again with whatever is here, which will cause the wrapper
@@ -187,13 +214,24 @@ class Manager:
             pyfuncitem.obj = func
 
             result_file = _build_bin_path()
-            with Tracker(
-                result_file,
-                native_traces=native,
-                trace_python_allocators=trace_python_allocators,
-                file_format=FileFormat.AGGREGATED_ALLOCATIONS,
-            ):
-                yield
+            tracker_kwargs = {
+                "native_traces": native,
+                "trace_python_allocators": trace_python_allocators,
+                "file_format": FileFormat.AGGREGATED_ALLOCATIONS,
+            }
+
+            # Add track_object_lifetimes if tracking objects
+            if track_objects:  # pragma: no cover
+                tracker_kwargs["track_object_lifetimes"] = True
+
+            # mypy can't resolve the overload when using **kwargs unpacking
+            tracker = Tracker(result_file, **tracker_kwargs)  # type: ignore[call-overload]
+            yield (tracker, track_objects)
+
+            # Get surviving objects if tracking was enabled
+            surviving_objects = None
+            if track_objects:  # pragma: no cover
+                surviving_objects = list(tracker.get_surviving_objects())
 
             try:
                 metadata = FileReader(result_file).metadata
@@ -207,15 +245,34 @@ class Manager:
                 pickle.dump(result, file_handler)
             self.results[pyfuncitem.nodeid] = result
 
+            # Store surviving objects separately (they can't be pickled)
+            if surviving_objects is not None:  # pragma: no cover
+                self.surviving_objects[pyfuncitem.nodeid] = surviving_objects
+
+        def _settle_tracked_objects(track_objects: bool) -> None:
+            # Collect cycles and drop interpreter-internal caches so that
+            # objects kept alive only by them aren't reported as leaks.
+            if track_objects:
+                gc.collect()
+                sys._clear_internal_caches()  # type: ignore[attr-defined]
+
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            with memory_reporting():
-                return func(*args, **kwargs)
+            with memory_reporting() as (tracker, track_objects):
+                with tracker:
+                    try:
+                        return func(*args, **kwargs)
+                    finally:
+                        _settle_tracked_objects(track_objects)
 
         @functools.wraps(func)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-            with memory_reporting():
-                return await func(*args, **kwargs)
+            with memory_reporting() as (tracker, track_objects):
+                with tracker:
+                    try:
+                        return await func(*args, **kwargs)
+                    finally:
+                        _settle_tracked_objects(track_objects)
 
         if inspect.iscoroutinefunction(func):
             pyfuncitem.obj = async_wrapper
@@ -244,9 +301,19 @@ class Manager:
             result = self.results.get(item.nodeid)
             if not result:
                 continue
+            # Pass surviving_objects for object tracking markers
+            kwargs = dict(marker.kwargs)
+            if marker.name == "limit_leaked_objects":  # pragma: no cover
+                # Pop rather than get: the Manager lives for the whole session,
+                # so keeping a reference here would hold every "leaked" object
+                # (and everything it references) alive until pytest exits.
+                surviving_objects = self.surviving_objects.pop(item.nodeid, None)
+                if surviving_objects is not None:
+                    kwargs["_surviving_objects"] = surviving_objects
+
             res = marker_fn(
                 *marker.args,
-                **marker.kwargs,
+                **kwargs,
                 _result_file=result.result_file,
                 _config=self.config,
                 _test_id=item.nodeid,
@@ -339,7 +406,11 @@ class Manager:
         writeln("\t 🥇 Biggest allocating functions:")
         sorted_records = sorted(records, key=lambda _record: _record.size, reverse=True)
         for record in islice(sorted_records, N_TOP_ALLOCS):
-            stack_trace = record.stack_trace()
+            try:
+                stack_trace = record.stack_trace()
+            except NotImplementedError:
+                # Stack traces for deallocations aren't captured
+                continue
             if not stack_trace:
                 continue
             (function, file, line), *_ = stack_trace

--- a/tests/test_object_tracking.py
+++ b/tests/test_object_tracking.py
@@ -1,0 +1,136 @@
+"""Tests for object tracking functionality."""
+
+import sys
+
+import pytest
+
+# Skip all tests if Python version is too old
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 13, 3),
+    reason="Object tracking requires Python 3.13.3+",
+)
+
+
+class TestObjectTracking:
+    """Test the limit_leaked_objects marker."""
+
+    def test_objects_are_tracked_and_reported(self, pytester):
+        """Test that leaked objects are detected and reported."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.limit_leaked_objects
+            def test_leak_objects():
+                # Create objects that will leak
+                leaked_list = [1, 2, 3, 4, 5]
+                leaked_dict = {"key": "value", "number": 42}
+
+                # Store them in the test instance to make them survive
+                test_leak_objects._leaked = [leaked_list, leaked_dict]
+            """
+        )
+
+        result = pytester.runpytest("--memray")
+
+        assert result.ret == pytest.ExitCode.TESTS_FAILED
+        output = result.stdout.str()
+
+        # Check that the report mentions leaked objects
+        assert "Test leaked" in output
+        assert "objects" in output
+        assert "Object types that leaked" in output
+        assert "list" in output
+        assert "dict" in output
+
+    def test_no_frames_leak(self, pytester):
+        """Test that when no user objects leak, no frames survive either."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.limit_leaked_objects
+            def test_no_leak():
+                # Create temporary objects that will be garbage collected
+                temp_list = [1, 2, 3]
+                temp_dict = {"temp": "value"}
+
+                # Use them but don't keep references
+                assert len(temp_list) == 3
+                assert "temp" in temp_dict
+
+                # Force garbage collection
+                temp_list = None
+                temp_dict = None
+            """
+        )
+
+        result = pytester.runpytest("--memray")
+        output = result.stdout.str()
+        assert result.ret == 0
+        assert "instance(s)" not in output
+
+    def test_complex_object_types(self, pytester):
+        """Test tracking of various object types."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            class CustomClass:
+                def __init__(self, value):
+                    self.value = value
+                def __repr__(self):
+                    return f"CustomClass({self.value})"
+
+            @pytest.mark.limit_leaked_objects
+            def test_various_types():
+                # Create various types of objects
+                test_various_types._leaks = {
+                    "custom": CustomClass(42),
+                    "set": {1, 2, 3},
+                    "bytes": b"leaked bytes",
+                    "tuple": (1, 2, 3),
+                    "nested": {
+                        "list": [1, [2, 3]],
+                        "dict": {"a": {"b": "c"}}
+                    }
+                }
+            """
+        )
+
+        result = pytester.runpytest("--memray")
+
+        assert result.ret == pytest.ExitCode.TESTS_FAILED
+        output = result.stdout.str()
+
+        assert "CustomClass" in output
+        assert "dict" in output
+
+    def test_large_number_of_leaks(self, pytester):
+        """Test with many leaked objects."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.limit_leaked_objects
+            def test_many_leaks():
+                # Create many objects
+                test_many_leaks._leaks = []
+                for i in range(100):
+                    test_many_leaks._leaks.append({
+                        "id": i,
+                        "data": f"Object {i}"
+                    })
+            """
+        )
+
+        result = pytester.runpytest("--memray")
+
+        assert result.ret == pytest.ExitCode.TESTS_FAILED
+        output = result.stdout.str()
+
+        # Should show summary
+        assert "dict" in output
+        assert "instance(s)" in output
+        assert "... and " in output
+        assert " more" in output

--- a/tests/test_object_tracking.py
+++ b/tests/test_object_tracking.py
@@ -43,6 +43,66 @@ class TestObjectTracking:
         assert "list" in output
         assert "dict" in output
 
+    def test_ignoring_some_leaked_objects(self, pytester):
+        """Test that leaked objects can be ignored."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            def is_not_dict(obj: object) -> bool:
+                return not isinstance(obj, dict)
+
+            @pytest.mark.limit_leaked_objects(filter_fn=is_not_dict)
+            def test_leak_objects():
+                # Create objects that will leak
+                leaked_list = [1, 2, 3, 4, 5]
+                leaked_dict = {"key": "value", "number": 42}
+
+                # Store them in the test instance to make them survive
+                test_leak_objects._leaked = [leaked_list, leaked_dict]
+            """
+        )
+
+        result = pytester.runpytest("--memray")
+
+        assert result.ret == pytest.ExitCode.TESTS_FAILED
+        output = result.stdout.str()
+
+        # Check that the report mentions leaked objects
+        assert "Test leaked" in output
+        assert "objects" in output
+        assert "Object types that leaked" in output
+        assert "list" in output
+        assert "dict" not in output
+
+    def test_ignoring_all_leaked_objects(self, pytester):
+        """Test that the test passes if all leaked objects are ignored."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.limit_leaked_objects(filter_fn=lambda obj: False)
+            def test_leak_objects():
+                # Create objects that will leak
+                leaked_list = [1, 2, 3, 4, 5]
+                leaked_dict = {"key": "value", "number": 42}
+
+                # Store them in the test instance to make them survive
+                test_leak_objects._leaked = [leaked_list, leaked_dict]
+            """
+        )
+
+        result = pytester.runpytest("--memray")
+
+        assert result.ret == 0
+        output = result.stdout.str()
+
+        # Check that the report doesn't mention any leaked objects
+        assert "Test leaked" not in output
+        assert "Object types that leaked" not in output
+        assert "list" not in output
+        assert "dict" not in output
+
     def test_no_frames_leak(self, pytester):
         """Test that when no user objects leak, no frames survive either."""
         pytester.makepyfile(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist =
+    py314
+    py313
     py312-cov
     py312
     py311
@@ -40,7 +42,7 @@ description = invoke sphinx-build to build the HTML docs
 setenv =
     VIRTUALENV_NO_SETUPTOOLS = false
     VIRTUALENV_NO_WHEEL = false
-basepython = python3.10
+basepython = python3.14
 dependency_groups =
     docs
 commands =
@@ -49,6 +51,7 @@ commands =
 [testenv:lint]
 description = lint code in {basepython}
 basepython = python3.8
+extras =
 dependency_groups =
     lint
 commands =
@@ -61,7 +64,7 @@ whitelist_externals =
 description = cut a new release
 setenv =
     {[testenv:docs]setenv}
-basepython = python3.10
+basepython = python3.14
 skip_install = true
 deps =
     towncrier>=22.12
@@ -72,7 +75,7 @@ commands =
 description = generate a development environment
 setenv =
     {[testenv:docs]setenv}
-basepython = python3.10
+basepython = python3.14
 dependency_groups =
     docs
     lint


### PR DESCRIPTION
This commit adds support for tracking Python objects that survive test execution
using the new reference tracking API introduced in memray (commit e567c3cf).

*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
A clear and concise description of the changes you have made.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
