### PR TITLE
ci: Switch to Trusted Publishing

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -32,6 +32,8 @@ jobs:
     needs: [build_dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    permissions:
+      id-token: write # Required to retrieve a Trusted Publishing token
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -39,5 +41,3 @@ jobs:
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.14.0
-        with:
-          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Stop using long-lived secrets for PyPI publishing.