### PR TITLE
docs: macOS support + dependency groups (#166, #167)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,9 @@ build:
     python: "3"
 python:
   install:
-    - method: pip
-      path: .
-      extra_requirements:
+    - method: uv
+      command: sync
+      groups:
         - docs
 sphinx:
   builder: html

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install-sdist: dist  ## Install from source distribution
 
 .PHONY: test-install
 test-install:  ## Install with test dependencies
-	$(ENV) $(PIP_INSTALL) -e .[test]
+	$(ENV) $(PIP_INSTALL) -e . --group test
 
 .PHONY: check
 check:

--- a/README.md
+++ b/README.md
@@ -176,9 +176,12 @@ You must use your real name (sorry, no pseudonyms, and no anonymous contribution
 
 ### Development
 
-The project requires a Linux OS to work. To set up a DEV environment use tox (or
-directly the make targets). You can use Docker to run the test suite on non Linux as in
-(you can parametrize tox by passing additional arguments at the end):
+pytest-memray runs wherever [Memray](https://github.com/bloomberg/memray) is supported
+(Linux and macOS). To set up a development environment on either platform, use tox (or
+the Make targets directly).
+
+On other platforms you can run the test suite in Docker (you can parametrize tox by
+passing additional arguments at the end):
 
 ```shell
 docker-compose run --rm test tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,28 +22,6 @@ dependencies = [
   "pytest>=7.2",
   "memray>=1.12",
 ]
-optional-dependencies.docs = [
-  "furo>=2022.12.7",
-  "sphinx>=6.1.3",
-  "sphinx-argparse>=0.4",
-  "sphinx-inline-tabs>=2022.1.2b11",
-  "sphinxcontrib-programoutput>=0.17",
-  "towncrier>=22.12",
-]
-optional-dependencies.lint = [
-  "black==24.8.0",
-  "ruff==0.12.7",
-  "isort==5.13.2",
-  "mypy==1.14.1",
-]
-optional-dependencies.test = [
-  "anyio>=4.4.0",
-  "covdefaults>=2.2.2",
-  "pytest>=7.2",
-  "coverage>=7.0.5",
-  "flaky>=3.7",
-  "pytest-xdist>=3.1",
-]
 dynamic = ["version"]
 classifiers = [
   "Intended Audience :: Developers",
@@ -63,6 +41,30 @@ classifiers = [
 
 [project.entry-points.pytest11]
 memray = "pytest_memray.plugin"
+
+[dependency-groups]
+docs = [
+  "furo>=2022.12.7",
+  "sphinx>=6.1.3",
+  "sphinx-argparse>=0.4",
+  "sphinx-inline-tabs>=2022.1.2b11",
+  "sphinxcontrib-programoutput>=0.17",
+  "towncrier>=22.12",
+]
+lint = [
+  "black==24.8.0",
+  "ruff==0.12.7",
+  "isort==5.13.2",
+  "mypy==1.14.1",
+]
+test = [
+  "anyio>=4.4.0",
+  "covdefaults>=2.2.2",
+  "pytest>=7.2",
+  "coverage>=7.0.5",
+  "flaky>=3.7",
+  "pytest-xdist>=3.1",
+]
 
 [tool.hatch]
 build.dev-mode-dirs = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dynamic = ["version"]
 classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
+  "Operating System :: MacOS",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     py38
     docs
     lint
-requires = tox>=4.2
+requires = tox>=4.4
 
 [testenv]
 description =
@@ -22,7 +22,7 @@ setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
     VIRTUALENV_NO_SETUPTOOLS = true
     VIRTUALENV_NO_WHEEL = true
-extras =
+dependency_groups =
     test
 commands =
     make check
@@ -41,7 +41,7 @@ setenv =
     VIRTUALENV_NO_SETUPTOOLS = false
     VIRTUALENV_NO_WHEEL = false
 basepython = python3.10
-extras =
+dependency_groups =
     docs
 commands =
     make docs
@@ -49,7 +49,7 @@ commands =
 [testenv:lint]
 description = lint code in {basepython}
 basepython = python3.8
-extras =
+dependency_groups =
     lint
 commands =
     make lint
@@ -73,7 +73,7 @@ description = generate a development environment
 setenv =
     {[testenv:docs]setenv}
 basepython = python3.10
-extras =
+dependency_groups =
     docs
     lint
     test


### PR DESCRIPTION
## Summary

Closes #166 and #167.

### #166 — macOS support
- Update README dev instructions (Linux + macOS, not Linux-only).
- Add `Operating System :: MacOS` PyPI classifier.

### #167 — dependency groups
- Move `docs` / `lint` / `test` to PEP 735 `[dependency-groups]`.
- tox: `extras` → `dependency_groups`, require tox>=4.4.
- Makefile: `pip install -e . --group test`.

## Test plan
- [ ] `tox -e lint`
- [ ] `tox -e py312` on Linux or macOS