### PR TITLE
Reduce verbosity of @limit_memory failure output

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -56,3 +56,10 @@ The complete list of command line options is:
 
   ``fail-on-increase(bool)``
     Fail a test with the limit_memory marker if it uses more memory than its last successful run
+
+  ``verbosity_memray(string)``
+    Verbosity level for limit_memory failure reports.
+    At negative levels the limit_memory marker only reports a summary,
+    at level 0 or 1 it shows the top 10 allocations by size,
+    from level 2 up it shows all allocations. The default follows pytest's
+    -v / -q flags (with 0 as the default if neither are given).

--- a/docs/news/142.feature.rst
+++ b/docs/news/142.feature.rst
@@ -1,0 +1,1 @@
+Control how much detail the ``limit_memory`` marker shows on failure via pytest's ``-v`` / ``-q`` flags or the ``verbosity_memray`` ini option. At the default level or ``-v`` the top 10 allocations by size are shown; ``-vv`` lists every allocation; ``-q`` hides the allocation list entirely, leaving only the one-line failure summary.

--- a/docs/news/142.removal.rst
+++ b/docs/news/142.removal.rst
@@ -1,0 +1,1 @@
+Drop support for pytest 7.x, which was superseded in January 2024.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ maintainers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "pytest>=7.2",
+  "pytest>=8.0",
   "memray>=1.19.1",
 ]
 dynamic = ["version"]
@@ -60,7 +60,7 @@ lint = [
 test = [
   "anyio>=4.4.0",
   "covdefaults>=2.2.2",
-  "pytest>=7.2",
+  "pytest>=8.0",
   "coverage>=7.0.5",
   "flaky>=3.7",
   "pytest-xdist>=3.1",

--- a/src/pytest_memray/marks.py
+++ b/src/pytest_memray/marks.py
@@ -99,13 +99,22 @@ class _MemoryInfo:
     num_stacks: int
     native_stacks: bool
     total_allocated_memory: int
+    verbosity: int
 
     @property
-    def section(self) -> PytestSection:
+    def section(self) -> Optional[PytestSection]:
         """Return a tuple in the format expected by section reporters."""
-        body = _generate_section_text(
-            self.allocations, self.native_stacks, self.num_stacks
-        )
+        if self.verbosity < 0:
+            return None
+        if self.verbosity >= 2:
+            allocations = self.allocations
+        else:
+            allocations = sorted(self.allocations, key=lambda r: r.size, reverse=True)
+            allocations = allocations[:10]
+        body = _generate_section_text(allocations, self.native_stacks, self.num_stacks)
+        remaining = len(self.allocations) - len(allocations)
+        if remaining > 0:
+            body += f"\n    ...and {remaining} more"
         return (
             "memray-max-memory",
             "List of allocations:\n" + body,
@@ -245,6 +254,7 @@ def limit_memory(
         num_stacks=num_stacks,
         native_stacks=native_stacks,
         total_allocated_memory=total_allocated_memory,
+        verbosity=_config.get_verbosity("memray"),
     )
 
 

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -50,7 +50,7 @@ from .utils import value_or_ini
 
 class SectionMetadata(Protocol):
     long_repr: str
-    section: Tuple[str, str]
+    section: Tuple[str, str] | None
 
 
 class PluginFn(Protocol):
@@ -321,7 +321,8 @@ class Manager:
             if res:
                 report.outcome = "failed"
                 report.longrepr = res.long_repr
-                report.sections.append(res.section)
+                if res.section is not None:
+                    report.sections.append(res.section)
                 outcome.force_result(report)
         return None
 
@@ -501,6 +502,17 @@ def pytest_addoption(parser: Parser) -> None:
         "fail-on-increase",
         help="Fail a test with the limit_memory marker if it uses more memory than its last successful run",
         type="bool",
+    )
+    parser.addini(
+        "verbosity_memray",
+        help=(
+            "Verbosity level for limit_memory failure reports. "
+            "At negative levels the limit_memory marker only reports a summary, "
+            "at level 0 or 1 it shows the top 10 allocations by size, "
+            "from level 2 up it shows all allocations. The default follows pytest's "
+            "-v / -q flags (with 0 as the default if neither are given)."
+        ),
+        default="auto",
     )
     help_msg = "Show the N tests that allocate most memory (N=0 for all)"
     parser.addini("most_allocations", help_msg)

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -204,6 +204,84 @@ def test_memray_report_limit_number_stacks(num_stacks: int, pytester: Pytester) 
     assert num_rec_frames == min(num_stacks - 1, 10)
 
 
+@pytest.mark.parametrize(
+    "extra_args, expect_allocations",
+    [
+        (["-q"], False),
+        ([], True),
+        (["-v"], True),
+        (["-vv"], True),
+        (["-vvv"], True),
+        (["-o", "verbosity_memray=2"], True),
+        (["-vv", "-o", "verbosity_memray=-1"], False),
+    ],
+)
+def test_limit_memory_allocation_list_visibility(
+    pytester: Pytester, extra_args: list[str], expect_allocations: bool
+) -> None:
+    pytester.makepyfile(
+        """
+        import pytest
+        from memray._test import MemoryAllocator
+        allocator = MemoryAllocator()
+
+        @pytest.mark.limit_memory("1KB")
+        def test_foo():
+            allocator.valloc(1024 * 4)
+            allocator.free()
+        """
+    )
+
+    result = pytester.runpytest("--memray", *extra_args)
+    assert result.ret == ExitCode.TESTS_FAILED
+    stacks = extract_stacks(result.stdout.str())
+    assert bool(stacks) is expect_allocations
+
+
+@pytest.mark.parametrize(
+    "extra_args, expect_all",
+    [
+        ([], False),
+        (["-v"], False),
+        (["-vv"], True),
+    ],
+)
+def test_limit_memory_allocation_list_truncation(
+    pytester: Pytester, extra_args: list[str], expect_all: bool
+) -> None:
+    pytester.makepyfile(
+        """
+        import pytest
+        from memray._test import MemoryAllocator
+
+        def rec(n, allocators):
+            a = MemoryAllocator()
+            a.valloc(1024)
+            allocators.append(a)
+            if n > 1:
+                rec(n - 1, allocators)
+
+        @pytest.mark.limit_memory("1KB")
+        def test_foo():
+            allocators = []
+            rec(15, allocators)
+            for a in allocators:
+                a.free()
+        """
+    )
+
+    result = pytester.runpytest(*extra_args)
+    assert result.ret == ExitCode.TESTS_FAILED
+    output = result.stdout.str()
+    stacks = extract_stacks(output)
+    if expect_all:
+        assert len(stacks) > 10
+        assert "...and" not in output
+    else:
+        assert len(stacks) == 10
+        assert "...and" in output
+
+
 @pytest.mark.parametrize("native", [True, False])
 def test_memray_report_native(native: bool, pytester: Pytester) -> None:
     pytester.makepyfile(


### PR DESCRIPTION
Closes #142.

## Context — PyCon US sprint

Prototyped at the PyCon US sprint. The first draft rolled its own ini lookup, but a maintainer pointed me at pytest's standard helper for this case: [`Config.get_verbosity(verbosity_type)`](https://docs.pytest.org/en/stable/reference/reference.html#pytest.Config.get_verbosity). The current implementation defers to that.

## Why the fallback

`Config.get_verbosity` only exists in pytest 8.0+. This package still declares `pytest>=7.2`, so I kept a small `try/except AttributeError` block that mirrors the helper's behavior on older pytest. Happy to drop it and bump `pytest>=8.0` instead — say the word and I'll squash.