### PR TITLE
Secure GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
     # At 12:00 UTC on every day-of-month
     - cron: "0 12 */1 * *"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -31,14 +34,16 @@ jobs:
           - { "py": "3.8", "tox_env": "py38" }
     steps:
       - name: setup python for tox
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       - name: install tox
         run: python -m pip install tox
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: setup python for test ${{ matrix.py }}
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.py }}-dev
       - name: setup test suite ${{ matrix.tox_env }}
@@ -50,9 +55,11 @@ jobs:
     name: check docs
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: setup Python 3.14
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
       - name: install tox
@@ -66,10 +73,12 @@ jobs:
     name: lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # mypy needs to be run with the oldest Python version we support.
       - name: setup Python 3.8
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.8"
       - name: Install prettier

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,8 +81,6 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.8"
-      - name: Install prettier
-        run: npm install -g prettier
       - name: install tox
         run: python -m pip install tox
       - name: install lint dependencies

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -10,6 +10,9 @@ on:
     # At 12:00 UTC on every day-of-month
     - cron: "0 12 */1 * *"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -19,12 +22,14 @@ jobs:
     name: Source and wheel distributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build distributions
         run: pipx run build[virtualenv] --sdist --wheel
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           path: dist/*
 
@@ -35,9 +40,9 @@ jobs:
     permissions:
       id-token: write # Required to retrieve a Trusted Publishing token
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.14.1
+      - uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build distributions
         run: pipx run build[virtualenv] --sdist --wheel
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: dist/*
 
@@ -40,7 +40,7 @@ jobs:
     permissions:
       id-token: write # Required to retrieve a Trusted Publishing token
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: artifact
           path: dist

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7


### PR DESCRIPTION
*Issue number of the reported bug or feature request: Closes #164*

**Describe your changes**

- Pin every third-party action to an immutable commit while retaining version comments for Dependabot.
- Restrict workflow token permissions and disable checkout credential persistence.
- Remove the unused ad-hoc Prettier installation.
- Add the official zizmor action with scoped SARIF permissions.

**Testing performed**

- `uvx zizmor .` reports no findings.
- All workflow YAML files parse successfully with Ruby Psych.
- `git diff --check` passes.
- actionlint v1.7.12 introduces no new diagnostic; its sole SC2102 result for the unchanged `pipx run build[virtualenv]` line reproduces on `main`.

**Additional context**

The pinned commits were verified against the version tags documented beside each action reference.