### PR TITLE
👷 ci(github): test against Python 3.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - { "py": "3.15", "tox_env": "py315" }
           - { "py": "3.14", "tox_env": "py314" }
           - { "py": "3.13", "tox_env": "py313" }
           - { "py": "3.12", "tox_env": "py312-cov" }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,10 @@ jobs:
         uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ matrix.py }}-dev
+      # memray has no cp315 wheels yet, so py315 builds it from source
+      - name: install memray build dependencies
+        if: matrix.tox_env == 'py315'
+        run: sudo apt-get update -q && sudo apt-get install -qy libdebuginfod-dev libunwind-dev liblz4-dev pkg-config
       - name: setup test suite ${{ matrix.tox_env }}
         run: tox -vv --notest -e ${{ matrix.tox_env }}
       - name: run test suite ${{ matrix.tox_env }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    py315
     py314
     py313
     py312-cov

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,11 @@ allowlist_externals =
 package = wheel
 wheel_build_env = .pkg
 
+[testenv:py315]
+deps =
+    # memray 1.19.3 ships no cp315 wheels; use main until a release with 3.15 support
+    memray @ git+https://github.com/bloomberg/memray.git
+
 [testenv:py312-cov]
 commands =
     make coverage


### PR DESCRIPTION
Python 3.15 is at beta 4. Adding it to CI now surfaces breakage while there is still time to report it upstream, ahead of the release candidate.

The change mirrors the 3.14 addition in e709c83: one matrix entry in `build.yml` and the matching env in the tox `envlist`. It needs no prerelease handling, because the `${{ matrix.py }}-dev` suffix already on `setup-python` resolves to the newest available build. The job picked up `3.15.0-beta.4` and created its virtualenv without trouble. 🐍 It also skips the classifier. The 3.14 classifier landed once 3.14 reached rc, and 3.15 is still in beta, so this starts testing the version short of declaring support for it.

memray ships no `cp315` wheels; its newest release, [1.19.3](https://pypi.org/project/memray/1.19.3/), covers `cp38` through `cp314`, so on 3.15 pip falls back to the sdist and the build stops at `fatal error: libunwind.h: No such file or directory`. Upstream merged 3.15 support when it closed [Support Python 3.15](https://github.com/bloomberg/memray/issues/920) on 2026-05-20, six weeks after publishing 1.19.3 on 2026-04-08, so that work exists on `main` but not in any release.

To test something real in the meantime, the `py315` tox env installs `memray @ git+https://github.com/bloomberg/memray.git` and the `py315` CI leg alone installs the apt packages memray's own CI uses to build from source (`libdebuginfod-dev`, `libunwind-dev`, `liblz4-dev`, `pkg-config`). The job exercises memray's merged 3.15 support rather than a stale sdist, while every other leg keeps installing released memray from PyPI. ⏳ The git pin and the extra apt step are temporary; drop both once memray cuts a release with `cp315` wheels.
