### PR TITLE
Limit generated file names to 255 characters

### DIFF
--- a/docs/news/136.bugfix.rst
+++ b/docs/news/136.bugfix.rst
@@ -1,0 +1,1 @@
+Truncate binary dump file names that exceed the file system limit, so tests with long node ids (deeply nested paths or verbose parametrization) no longer fail with ``OSError: File name too long``.

--- a/src/pytest_memray/plugin.py
+++ b/src/pytest_memray/plugin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import functools
 import gc
+import hashlib
 import inspect
 import math
 import os
@@ -71,6 +72,26 @@ MARKERS = {
 
 N_TOP_ALLOCS = 5
 N_HISTOGRAM_BINS = 5
+# Most file systems cap a single path component at 255 bytes. The sibling
+# metadata file replaces the ".bin" suffix with the longer ".metadata" one, so
+# leave room for that too.
+MAX_FILENAME_LENGTH = 255 - (len(".metadata") - len(".bin"))
+
+
+def _truncate_filename(name: str, max_length: int = MAX_FILENAME_LENGTH) -> str:
+    """Shorten *name* so it fits in a single path component.
+
+    Long test ids -- from deeply nested test paths or verbose parametrization --
+    can produce names the file system rejects. The tail is replaced with a
+    digest of the full name so truncated names stay unique.
+    """
+    encoded = name.encode("utf-8")
+    if len(encoded) <= max_length:
+        return name
+    digest = hashlib.sha256(encoded).hexdigest()[:16]
+    suffix = f"-{digest}.bin"
+    keep = max_length - len(suffix)
+    return encoded[:keep].decode("utf-8", "ignore") + suffix
 
 
 def histogram(
@@ -185,7 +206,7 @@ class Manager:
             if self._tmp_dir is None and not os.getenv("MEMRAY_RESULT_PATH"):
                 of_id = pyfuncitem.nodeid.replace("::", "-")
                 of_id = of_id.replace(os.sep, "-")
-                name = f"{self._bin_prefix}-{of_id}.bin"
+                name = _truncate_filename(f"{self._bin_prefix}-{of_id}.bin")
             else:
                 name = f"{uuid.uuid4().hex}.bin"
             result_file = self.result_path / name

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -594,6 +594,84 @@ def test_bin_path(pytester: Pytester) -> None:
     assert f"Created 3 binary dumps at {dump} with prefix H" in output
 
 
+def test_bin_path_with_long_test_id(
+    pytester: Pytester, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("MEMRAY_RESULT_PATH", raising=False)
+    py = """
+    import pytest
+
+    @pytest.mark.parametrize('v', ['a' * 300])
+    def test_a(v):
+        assert [1]
+    """
+    pytester.makepyfile(**{"test_a": py})
+    dump = pytester.path / "d"
+    result = pytester.runpytest_subprocess(
+        "--memray",
+        "--memray-bin-path",
+        str(dump),
+        "--memray-bin-prefix",
+        "352f3f34aa644bc2b3672ef467430223",
+    )
+
+    assert result.ret == ExitCode.OK
+
+    expected_stem = (
+        "352f3f34aa644bc2b3672ef467430223"
+        + "-test_a.py-test_a["
+        + ("a" * 179)
+        + "-88c716620b48351a"
+    )
+
+    dumps = [i.name for i in dump.iterdir() if i.name != "metadata"]
+    assert len(dumps) == 1
+    assert dumps[0] == f"{expected_stem}.bin"
+    metadata = list((dump / "metadata").iterdir())
+    assert len(metadata) == 1
+    assert metadata[0].name == f"{expected_stem}.metadata"
+    assert len(metadata[0].name.encode("utf-8")) == 255
+
+
+def test_bin_path_with_long_test_id_and_long_prefix(
+    pytester: Pytester, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("MEMRAY_RESULT_PATH", raising=False)
+    py = """
+    import pytest
+
+    @pytest.mark.parametrize('v', ['a' * 300])
+    def test_a(v):
+        assert [1]
+    """
+    pytester.makepyfile(**{"test_a": py})
+    dump = pytester.path / "d"
+    result = pytester.runpytest_subprocess(
+        "--memray",
+        "--memray-bin-path",
+        str(dump),
+        "--memray-bin-prefix",
+        "352f3f34aa644bc2b3672ef467430223" * 3,
+    )
+
+    assert result.ret == ExitCode.OK
+
+    expected_stem = (
+        ("352f3f34aa644bc2b3672ef467430223" * 3)
+        + "-test_a.py-test_a["
+        + ("a" * 115)
+        + "-3e4fe15eabd37073"
+    )
+
+    dumps = [i.name for i in dump.iterdir() if i.name != "metadata"]
+    assert len(dumps) == 1
+    assert dumps[0] == f"{expected_stem}.bin"
+    metadata = list((dump / "metadata").iterdir())
+    assert len(metadata) == 1
+    assert metadata[0].name == f"{expected_stem}.metadata"
+    assert len(metadata[0].name.encode("utf-8")) == 255
+
+
 @pytest.mark.parametrize("override", [True, False])
 def test_bin_path_prefix(pytester: Pytester, override: bool) -> None:
     py = """


### PR DESCRIPTION
Closes #136
Closes #144 (a duplicate) as well.

A long pytest node id — from a deeply nested test path or verbose parametrization — makes `_build_bin_path` generate a name longer than the 255-byte limit most file systems place on a single path component, so tracking those tests fails with `OSError: File name too long` instead of running. The name is now truncated with a digest of the full name appended so truncated names stay unique; the budget leaves room for the sibling `.metadata` file, whose suffix is longer than `.bin`.

`test_bin_path_with_long_test_id` fails on `main` with the reported `OSError` and passes with the fix (it uses `runpytest_subprocess` so the plugin is re-imported).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
