### PR TITLE
tests: Loosen an assertion on a mangled name

### DIFF
--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -311,9 +311,9 @@ def test_memray_report_native(native: bool, pytester: Pytester) -> None:
     )
 
     if native:
-        assert "MemoryAllocator_1" in output
+        assert "MemoryAllocator_" in output
     else:
-        assert "MemoryAllocator_1" not in output
+        assert "MemoryAllocator_" not in output
 
 
 @pytest.mark.parametrize("trace_python_allocators", [True, False])


### PR DESCRIPTION
The latest builds of Memray are producing a native stack where this name is `__pyx_pf_6memray_11_test_utils_15MemoryAllocator_20valloc`, which doesn't match the pattern we were looking for. Loosen the assertion a bit.
