### PR TITLE
📄 docs: publish llms.txt from the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import sys
 from pathlib import Path
 from subprocess import check_output
@@ -10,6 +12,7 @@ from sphinx.application import Sphinx
 from sphinxcontrib.programoutput import Command
 
 extensions = [
+    "sphinx_llm.txt",
     "sphinx.ext.autodoc",
     "sphinx.ext.extlinks",
     "sphinx.ext.githubpages",
@@ -67,3 +70,6 @@ def setup(app: Sphinx) -> None:
     new = check_output(cmd, cwd=root, text=True)
     to = root / "docs" / "_draft.rst"
     to.write_text("" if "No significant changes" in new else new)
+
+
+markdown_http_base = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ memray = "pytest_memray.plugin"
 
 [dependency-groups]
 docs = [
+  "sphinx-llm>=0.4.1",
   "furo>=2022.12.7",
   "sphinx>=6.1.3",
   "sphinx-argparse>=0.4",


### PR DESCRIPTION
Agents and LLM tools read project documentation when they help someone use the project. Rendered HTML is a bad fit. Theme markup wraps the content, and some pages need JavaScript that agent fetchers do not run. The [llms.txt convention](https://llmstxt.org/) publishes the same content as plain markdown, so agents work from the current docs rather than a training snapshot. 🤖

The [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) extension emits `llms.txt`, `llms-full.txt`, and a markdown twin of each page during the regular HTML build. Read the Docs serves `llms.txt` from the docs domain root once it lands in the default version's build output ([announcement](https://about.readthedocs.com/blog/2026/02/llms-txt-support/)). Relative sitemap links would 404 there, hence `markdown_http_base` reads `READTHEDOCS_CANONICAL_URL` to keep them absolute.

The HTML output does not change. The docs build gains one dependency and a few generated files.
