### PR TITLE
Use prek for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.7
+    hooks:
+      - id: ruff-check
+        args: [--fix, --exit-non-zero-on-fix]
+
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 PYTHON ?= python
+# The prek executable supports Python 3.8; its Python module launcher does not.
+PREK ?= prek
 PRETTIER ?= prettier --no-editorconfig
 
 # Doc generation variables
@@ -9,7 +11,6 @@ PKG_CONFIG_PATH ?= /opt/bb/lib64/pkgconfig
 PIP_INSTALL=PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" $(PYTHON) -m pip install
 
 markdown_files := $(shell find . -name \*.md -not -path '*/\.*')
-python_files := $(shell find . -name \*.py -not -path '*/\.*')
 PURELIB=$(shell $(PYTHON) -c 'import sysconfig; print(sysconfig.get_path("purelib"))')
 # Use this to inject arbitrary commands before the make targets (e.g. docker)
 ENV :=
@@ -40,13 +41,11 @@ coverage:  ## Run the test suite, with Python code coverage
 
 .PHONY: format
 format:  ## Autoformat all files
-	$(PYTHON) -m ruff --fix $(python_files)
-	$(PYTHON) -m black $(python_files)
+	$(PREK) run --all-files
 
 .PHONY: lint
 lint:  ## Lint all files
-	$(PYTHON) -m ruff check $(python_files)
-	$(PYTHON) -m black --check --diff $(python_files)
+	$(PREK) run --all-files
 	$(PYTHON) -m mypy src/pytest_memray
 
 .PHONY: docs

--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ pytest-memray runs wherever [Memray](https://github.com/bloomberg/memray) is sup
 (Linux and macOS). To set up a development environment on either platform, use tox (or
 the Make targets directly).
 
+Install the development dependencies and the prek (pre-commit) hooks:
+
+```shell
+tox -e dev
+source .tox/dev/bin/activate
+prek install
+```
+
+You can then run the lint checks and test suite with:
+
+```shell
+make lint
+make check
+```
+
 On other platforms you can run the test suite in Docker (you can parametrize tox by
 passing additional arguments at the end):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,8 @@ docs = [
   "towncrier>=22.12",
 ]
 lint = [
-  "black==24.8.0",
-  "ruff==0.12.7",
-  "isort==5.13.2",
   "mypy==1.14.1",
+  "prek==0.4.13",
 ]
 test = [
   "anyio>=4.4.0",


### PR DESCRIPTION
## Summary

- add a pre-commit configuration that preserves the existing Ruff and Black versions and checks
- use `prek` as the lint and formatting driver while keeping mypy as a separate check
- document the development environment and hook installation workflow

## Why

Using `prek` keeps the lint workflow aligned with Memray while isolating Ruff and Black in hook environments. The `prek` executable is invoked directly so the lint job continues to work on the project's supported Python 3.8 environment.

## Validation

- `tox -e lint` with Python 3.8.20
- `make format`
- `make lint`
- `make check` (`98 passed, 6 skipped` on Python 3.12)
- `prek validate-config .pre-commit-config.yaml`
- `prek install` in a temporary checkout

Closes #178
