### PR TITLE
Handle disabled cacheprovider plugin

### DIFF
--- a/docs/news/130.bugfix.rst
+++ b/docs/news/130.bugfix.rst
@@ -1,0 +1,1 @@
+Allow tests using the ``limit_memory`` marker to run when pytest's cacheprovider plugin is disabled.

--- a/src/pytest_memray/marks.py
+++ b/src/pytest_memray/marks.py
@@ -234,15 +234,16 @@ def limit_memory(
     max_memory = parse_memory_string(limit)
     total_allocated_memory = sum(record.size for record in allocations)
 
-    if _config.cache is not None:
-        cache = _config.cache.get(f"memray/{_test_id}", {})
+    cache_provider = getattr(_config, "cache", None)
+    if cache_provider is not None:
+        cache = cache_provider.get(f"memray/{_test_id}", {})
         previous = cache.get("total_allocated_memory", float("inf"))
         fail_on_increase = cast(bool, value_or_ini(_config, "fail_on_increase"))
         if fail_on_increase and total_allocated_memory > previous:
             return _MoreMemoryInfo(previous, total_allocated_memory)
 
         cache["total_allocated_memory"] = total_allocated_memory
-        _config.cache.set(f"memray/{_test_id}", cache)
+        cache_provider.set(f"memray/{_test_id}", cache)
 
     if total_allocated_memory < max_memory:
         return None

--- a/tests/test_pytest_memray.py
+++ b/tests/test_pytest_memray.py
@@ -123,6 +123,22 @@ def test_limit_memory_marker_does_work_if_memray_not_passed(
     assert result.ret == ExitCode.TESTS_FAILED
 
 
+def test_limit_memory_marker_without_cacheprovider(pytester: Pytester) -> None:
+    pytester.makepyfile(
+        """
+        import pytest
+
+        @pytest.mark.limit_memory("1MB")
+        def test_memory_allocation():
+            pass
+        """
+    )
+
+    result = pytester.runpytest("--memray", "-p", "no:cacheprovider")
+
+    assert result.ret == ExitCode.OK
+
+
 @pytest.mark.parametrize(
     "memlimit, mem_to_alloc",
     [(5, 100), (10, 200)],


### PR DESCRIPTION
Closes #130

## Summary

When pytest's cacheprovider plugin is disabled, `Config.cache` is not defined. The `limit_memory` marker accessed it directly, causing an internal error instead of completing the test run.

This change retrieves the cache provider with `getattr` and only performs cache-backed memory comparisons when it is available. Existing behavior remains unchanged when cacheprovider is enabled. A regression test exercises `pytest --memray -p no:cacheprovider`, and a bugfix news fragment documents the fix.

## Testing

- Confirmed the regression test fails on `main` with `AttributeError: 'Config' object has no attribute 'cache'`.
- `pytest -q tests` — 99 passed, 6 skipped
- `coverage report` — 97% total coverage
- `ruff check src tests`
- `black --check --diff src tests`
- `mypy src/pytest_memray`
